### PR TITLE
Fix build failure against GCC 10 due to redefined globals

### DIFF
--- a/src/gtkdialog.c
+++ b/src/gtkdialog.c
@@ -40,6 +40,7 @@
 # include <glade/glade.h>
 #endif
 
+#define GTKDIALOG_NO_EXTERN
 #include "config.h"
 #include "gtkdialog.h"
 #include "variables.h"
@@ -81,6 +82,26 @@ gint geometry_dx = 0;
 gint geometry_dy = 0;
 gint geometry_x = 0;
 gint geometry_y = 0;
+
+/* Thunor: Used to block signal emissions from action functions */
+gint function_signals_block;
+
+/* Thunor: Used to control/override the widget packing expand and fill
+ * states at the project level */
+gint project_space_expand;
+gint project_space_fill;
+
+/* The most recently created radiobutton widget (used for grouping) */
+GtkWidget *lastradiowidget;
+
+/* An accumulated list of menu accelerator groups to be added to the window */
+GList *accel_groups;
+
+/* A list of widgets to hide and to show */
+GList *widget_hide_list, *widget_show_list;
+
+/* An auto-incremented unique id for each window created */
+gint window_id;
 
 static gboolean 
 get_geometry(const char *argument)

--- a/src/gtkdialog.h
+++ b/src/gtkdialog.h
@@ -36,28 +36,24 @@
 #define PRG_STDIN   2
 #define PRG_FILE    3
 
-/* Thunor: Used to block signal emissions from action functions */
 #define GTKD_FUNCTION_SIGNALS_BLOCK (function_signals_block++)
 #define GTKD_FUNCTION_SIGNALS_UNBLOCK (function_signals_block--)
 #define GTKD_FUNCTION_SIGNALS_RESET (function_signals_block = FALSE)
-gint function_signals_block;
 
-/* Thunor: Used to control/override the widget packing expand and fill
- * states at the project level */
-gint project_space_expand;
-gint project_space_fill;
+#ifndef GTKDIALOG_NO_EXTERN
+extern gint function_signals_block;
 
-/* The most recently created radiobutton widget (used for grouping) */
-GtkWidget *lastradiowidget;
+extern gint project_space_expand;
+extern gint project_space_fill;
 
-/* An accumulated list of menu accelerator groups to be added to the window */
-GList *accel_groups;
+extern GtkWidget *lastradiowidget;
 
-/* A list of widgets to hide and to show */
-GList *widget_hide_list, *widget_show_list;
+extern GList *accel_groups;
 
-/* An auto-incremented unique id for each window created */
-gint window_id;
+extern GList *widget_hide_list, *widget_show_list;
+
+extern gint window_id;
+#endif
 
 void reset_program_source(void);
 //Redundant: gint set_program_source(gchar *name);


### PR DESCRIPTION
Same problem as https://github.com/wjaguar/mtPaint/issues/46