### PR TITLE
Improve building with GTK3 and VTE

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -27,9 +27,23 @@ AM_PROG_LEX
 AC_PROG_YACC
 AC_SUBST(YACC)
 
-# *** gtk3: Newly added to support checking for the correct libraries.
+# *** gtk3: Support automatically checking for the correct libraries.
 AC_ARG_ENABLE([gtk3], AS_HELP_STRING([--enable-gtk3],
-	[Enable support for GTK+ 3 (GTK+ 2 is currently the default)]))
+	[Enable support for GTK+ 3 (GTK+ 2 is currently the default if both available)]))
+
+AC_ARG_WITH([gtkapi],
+	[AS_HELP_STRING([--with-gtkapi],
+		[Choose GTK+ api version (2.0 or 3.0) (default is auto)])],
+	[],
+	[with_gtkapi=auto])
+
+AS_IF([test "x$with_gtkapi" = "x3.0"], [enable_gtk3=yes],
+	[test "x$with_gtkapi" = "xauto"],
+		[PKG_CHECK_EXISTS([gtk+-2.0],,
+			[PKG_CHECK_EXISTS([gtk+-3.0],
+				[enable_gtk3=yes])
+			])
+		])
 
 # Checks for libraries.
 pkg_modules="gthread-2.0"
@@ -48,11 +62,14 @@ AS_IF([test "x$enable_gtk3" = "xyes"], [
 
 	AC_SUBST(HAVE_GLADE_LIB, 0)
 
-	vte_lib="vte >= 0.29.0"
-	PKG_CHECK_MODULES([VTE], \
-		[$vte_lib], \
-		AC_SUBST(HAVE_VTE, 1),\
-		AC_SUBST(HAVE_VTE, 0))
+	PKG_CHECK_MODULES([VTE],
+		[vte-2.91 >= 0.30.0],
+		AC_SUBST(HAVE_VTE, 1),
+		[PKG_CHECK_MODULES([VTE],
+			[vte-2.90 >= 0.30.0],
+			AC_SUBST(HAVE_VTE, 1),
+			AC_SUBST(HAVE_VTE, 0))]
+)
 	AC_SUBST(VTE_CFLAGS)
 	AC_SUBST(VTE_LIBS)
 ],

--- a/src/automaton.c
+++ b/src/automaton.c
@@ -722,7 +722,7 @@ static GtkWidget *put_in_the_scrolled_window(GtkWidget *widget,
 	glong             char_height;
 	glong             char_width;
 #if HAVE_VTE
-#if VTE_CHECK_VERSION(0,38,0)
+#if VTE_CHECK_VERSION(0,30,0)
 	GtkBorder         padding;
 #endif
 #endif
@@ -772,12 +772,10 @@ static GtkWidget *put_in_the_scrolled_window(GtkWidget *widget,
 			break;
 		case WIDGET_TERMINAL:
 #if HAVE_VTE
-			/* VTE is telling me that vte_terminal_get_padding() has been
-			 * deprecated since 0.26 and that I should get 'inner-border'
-			 * but GLib is telling me that 'VteTerminal' has no property
-			 * named 'inner-border' so I have to go with the deprecated
-			 * vte_terminal_get_padding() */
-#if VTE_CHECK_VERSION(0,38,0)
+#if VTE_CHECK_VERSION(0,30,0)
+			/* vte-0-30 is the first GTK3 only version, so it becomes
+			 * possible to use gtk_style_context_get_padding() instead
+			 * of the deprecated vte_terminal_get_padding() */
 			gtk_style_context_get_padding(gtk_widget_get_style_context(widget),
 				gtk_widget_get_state_flags(widget),
 				&padding);


### PR DESCRIPTION
Now configure should be able to automatically find the correct
versions of VTE for GTK3.

Also changed automaton.c to use gtk_style_context_get_padding()
for all GTK3 based builds.