### PR TITLE
src/widget_text.c: attempt 3 to fix wayland bug

### DIFF
--- a/src/widget_text.c
+++ b/src/widget_text.c
@@ -92,18 +92,26 @@ GtkWidget *widget_text_create(
 	gtk_label_set_line_wrap(GTK_LABEL(widget), TRUE);
 
 #if GTK_CHECK_VERSION(3,2,2)	/* gtk3: try global max-width-chars fix */
+	int max_width;
 	GdkDisplay * display = gdk_display_get_default();
 	GdkMonitor * monitor = gdk_display_get_primary_monitor(display);
-	int scale = gdk_monitor_get_scale_factor(monitor);
-	GdkRectangle workarea = {0};
-	gdk_monitor_get_workarea(monitor,&workarea);
-	int width = workarea.width / scale;
-	int max_width;
-	if ( width >= 1920 ) { /* make gui narrrower on wide screens*/
-		max_width = width / 24; 
+	/** hard code max_width = 80 if we can't find monitor
+	 * This happens in wayland and maybe other display servers
+	 */
+	if (!monitor) {
+		max_width = 80; 
 	} else {
-		max_width = width / 16; 
+		int scale = gdk_monitor_get_scale_factor(monitor);
+		GdkRectangle workarea = {0};
+		gdk_monitor_get_workarea(monitor,&workarea);
+		int width = workarea.width / scale;
+		if ( width >= 1920 ) { /* make gui narrrower on wide screens*/
+			max_width = width / 24; 
+		} else {
+			max_width = width / 16; 
+		}
 	}
+	
 	gtk_label_set_max_width_chars(GTK_LABEL(widget), max_width);
 #endif
 


### PR DESCRIPTION
closes #97

Check for error condition of `monitor`; if error hard code `max_width` else calcualte `max_width` from monitor properties.