### PR TITLE
Add layer shell support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,12 +11,25 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends libgtk2.0-dev libgtk-3-dev
-    - name: Build
+        sudo apt-get install -y --no-install-recommends libgtk2.0-dev libgtk-3-dev libvte-dev libvte-2.91-dev
+        python3 -m pip install meson ninja
+    - name: Copy source
       run: |
-        cp -r `pwd` ../gtk3
+        cp -r `pwd` ../gtk3-meson
+        cp -r `pwd` ../gtk3-autotools
+        cp -r `pwd` ../gtk2-autotools
+    - name: Meson build
+      run: |
+        meson --buildtype=release -Dgtkver=2 build
+        ninja -C build
+        cd ../gtk3-meson
+        meson --buildtype=release build
+        ninja -C build
+    - name: Autotools build
+      run: |
+        cd ../gtk2-autotools
         ./autogen.sh
         make -j`nproc`
-        cd ../gtk3
+        cd ../gtk3-autotools
         ./autogen.sh --enable-gtk3
         make -j`nproc`

--- a/README
+++ b/README
@@ -29,15 +29,22 @@ Get an older revision from SVN:
 Compilation and Installation
 ============================
 
-From a Source Package
----------------------
+Using Meson
+-----------
+
+    meson [configure-options] build
+    ninja -C build
+    ninja -C build install
+
+From a Source Package Using Autotools
+-------------------------------------
 
     ./configure [configure-options]
     make
     make install
 
-From SVN
---------
+From SVN Using Autotools
+------------------------
 
     ./autogen.sh [configure-options]
     make

--- a/meson.build
+++ b/meson.build
@@ -1,0 +1,15 @@
+project('gtkdialog', 'c', version: '0.8.4', license: 'GPLv2')
+
+gthread = dependency('gthread-2.0')
+
+gtkver = get_option('gtkver')
+
+if gtkver == 3
+	gtk = dependency('gtk+-3.0')
+	vte = dependency('vte-2.91', required: false)
+else
+	gtk = dependency('gtk+-2.0')
+	vte = dependency('vte', required: false)
+endif
+
+subdir('src')

--- a/meson.build
+++ b/meson.build
@@ -7,6 +7,11 @@ gtkver = get_option('gtkver')
 if gtkver == 3
 	gtk = dependency('gtk+-3.0')
 	vte = dependency('vte-2.91', required: false)
+	gtk_layer_shell = subproject(
+		'gtk-layer-shell',
+		default_options: ['default_library=static', 'introspection=false'],
+		required: false,
+	)
 else
 	gtk = dependency('gtk+-2.0')
 	vte = dependency('vte', required: false)

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,0 +1,1 @@
+option('gtkver', type: 'integer', value: 3, description: 'GTK+ version')

--- a/src/meson.build
+++ b/src/meson.build
@@ -1,0 +1,87 @@
+bison = generator(find_program('bison'),
+                  output: ['@BASENAME@.c', '@BASENAME@.h'],
+                  arguments: ['@INPUT@', '--defines=@OUTPUT1@', '--output=@OUTPUT0@', '-p', 'gtkdialog_'])
+
+flex = generator(find_program('flex'),
+                 output: '@BASENAME@.c',
+                 arguments: ['-P', 'gtkdialog_', '-o', '@OUTPUT@', '@INPUT@'])
+
+src = [
+	'actions.c',
+	'attributes.c',
+	'automaton.c',
+	'glade_support.c',
+	'gtkdialog.c',
+	'printing.c',
+	'signals.c',
+	'stack.c',
+	'stringman.c',
+	'tag_attributes.c',
+	'variables.c',
+	'widget_button.c',
+	'widget_checkbox.c',
+	'widget_colorbutton.c',
+	'widget_combobox.c',
+	'widget_comboboxtext.c',
+	'widget_edit.c',
+	'widget_entry.c',
+	'widget_eventbox.c',
+	'widget_expander.c',
+	'widget_fontbutton.c',
+	'widget_frame.c',
+	'widget_hbox.c',
+	'widget_hscale.c',
+	'widget_hseparator.c',
+	'widget_list.c',
+	'widget_menubar.c',
+	'widget_menuitem.c',
+	'widget_notebook.c',
+	'widget_pixmap.c',
+	'widget_progressbar.c',
+	'widget_radiobutton.c',
+	'widgets.c',
+	'widget_spinbutton.c',
+	'widget_statusbar.c',
+	'widget_table.c',
+	'widget_template.c',
+	'widget_terminal.c',
+	'widget_text.c',
+	'widget_timer.c',
+	'widget_tree.c',
+	'widget_vbox.c',
+	'widget_window.c'
+]
+
+cfg = configuration_data(
+	{
+		'HAVE_GTK': gtkver,
+	}
+)
+
+cfg.set_quoted('PACKAGE', meson.project_name())
+cfg.set_quoted('PACKAGE_NAME', meson.project_name())
+cfg.set_quoted('PACKAGE_VERSION', meson.project_version())
+cfg.set_quoted('BUILD_DETAILS', '') # TODO
+
+dep = [gtk, gthread]
+
+if vte.found()
+	dep += [vte]
+	cfg.set('HAVE_VTE', 1)
+else
+	cfg.set('HAVE_VTE', 0)
+endif
+
+configure_file(
+	output : 'config.h',
+	configuration : cfg,
+)
+
+gtkdialog = executable(
+	'gtkdialog',
+	bison.process('gtkdialog_parser.y'),
+	flex.process('gtkdialog_lexer.l'),
+	src,
+	dependencies: dep,
+	install: true,
+)

--- a/src/meson.build
+++ b/src/meson.build
@@ -71,6 +71,12 @@ if vte.found()
 else
 	cfg.set('HAVE_VTE', 0)
 endif
+if gtkver == 3 and gtk_layer_shell.found()
+	dep += [gtk_layer_shell.get_variable('gtk_layer_shell')]
+	cfg.set('HAVE_GTK_LAYER_SHELL', 1)
+else
+	cfg.set('HAVE_GTK_LAYER_SHELL', 0)
+endif
 
 configure_file(
 	output : 'config.h',

--- a/src/widget_window.c
+++ b/src/widget_window.c
@@ -23,6 +23,9 @@
 #define _GNU_SOURCE
 #include <gtk/gtk.h>
 #include "config.h"
+#if HAVE_GTK_LAYER_SHELL
+#include <gtk-layer-shell.h>
+#endif
 #include "gtkdialog.h"
 #include "attributes.h"
 #include "automaton.h"
@@ -93,6 +96,29 @@ GtkWidget *widget_window_create(
 
 	/* Create the window widget */
 	widget = gtk_window_new(GTK_WINDOW_TOPLEVEL);  
+
+#if HAVE_GTK_LAYER_SHELL
+	GtkLayerShellLayer layer = GTK_LAYER_SHELL_LAYER_ENTRY_NUMBER;
+
+	value = get_tag_attribute(attr, "layer");
+	if (value) {
+		if (strcmp(value, "background") == 0)
+			layer = GTK_LAYER_SHELL_LAYER_BACKGROUND;
+		else if (strcmp(value, "bottom") == 0)
+			layer = GTK_LAYER_SHELL_LAYER_BOTTOM;
+		else if (strcmp(value, "top") == 0)
+			layer = GTK_LAYER_SHELL_LAYER_TOP;
+		else if (strcmp(value, "overlay") == 0)
+			layer = GTK_LAYER_SHELL_LAYER_OVERLAY;
+		else
+			g_warning("%s(): Unknown layer %s.", __func__, value);
+	}
+
+	if (layer != GTK_LAYER_SHELL_LAYER_ENTRY_NUMBER) {
+		gtk_layer_init_for_window(GTK_WINDOW(widget));
+		gtk_layer_set_layer(GTK_WINDOW(widget), layer);
+	}
+#endif
 
 	/* Set a default window title */
 	attributeset_set_if_unset(Attr, ATTR_LABEL, PACKAGE);

--- a/subprojects/gtk-layer-shell.wrap
+++ b/subprojects/gtk-layer-shell.wrap
@@ -1,0 +1,3 @@
+[wrap-git]
+url = https://github.com/wmww/gtk-layer-shell
+revision = b5e0bbc7f2ac632a65db29193fa384baeb23a96c


### PR DESCRIPTION
To see it in action: add `layer="overlay"` to the `<window>` tag of /usr/lib/gtkdialog/box_splash.

This change is backward-compatible - current gtkdialog releases ignore this new attribute.