### PR TITLE
Remove widget_moved() from GTK+ 3 builds

### DIFF
--- a/src/automaton.c
+++ b/src/automaton.c
@@ -881,6 +881,7 @@ padding.top=%i padding.bottom=%i\n", __func__, padding.left,
 	return scrolledwindow;
 }
 
+#if !GTK_CHECK_VERSION(3,0,0)	/* gtk3: Redundant: WIDGET_GVIM is being purged */
 static
 gboolean widget_moved(GtkWidget *widget,
                       GdkEvent *event,
@@ -926,7 +927,6 @@ gboolean widget_moved(GtkWidget *widget,
 	return FALSE;
 }
 
-#if !GTK_CHECK_VERSION(3,0,0)	/* gtk3: Redundant: WIDGET_GVIM is being purged */
 static GtkWidget *
 create_gvim(AttributeSet * Attr)
 {


### PR DESCRIPTION
This function calls `gtk_widget_set_uposition()`, which is missing from GTK+ 3. Release builds against GTK+ 3 work, because this unresolved symbol is referenced by an unused function.