### PR TITLE
feature: scroll edit and text widgets to bottom on refresh

### DIFF
--- a/doc/reference/edit.html
+++ b/doc/reference/edit.html
@@ -151,6 +151,12 @@
 <td class="wiki"><tt>0</tt>, <tt>1</tt>, <tt>2</tt> (always, automatic, never)</td>
 <td class="wiki">0.8.1</td>
 </tr>
+<tr>
+<td class="wiki">scroll-to-bottom</td>
+<td class="wiki">Scroll to bottom on refresh</td>
+<td class="wiki"><tt>true</tt> or <tt>false</tt>
+<td class="wiki">0.8.4+</td>
+</tr>
 </tbody>
 </table>
 <h2 id="directives">Directives</h2>

--- a/doc/reference/text.html
+++ b/doc/reference/text.html
@@ -137,6 +137,48 @@
 <td class="wiki"><tt>true</tt> or <tt>false</tt></td>
 <td class="wiki">0.8.1</td>
 </tr>
+<tr>
+<td class="wiki">hscrollbar-policy</td>
+<td class="wiki">Policy for the horizontal scrollbar</td>
+<td class="wiki"><tt>0</tt>, <tt>1</tt>, <tt>2</tt> (always, automatic, never)</td>
+<td class="wiki">0.8.4+</td>
+</tr>
++<tr>
+<td class="wiki">vscrollbar-policy</td>
+<td class="wiki">Policy for the vertical scrollbar</td>
+<td class="wiki"><tt>0</tt>, <tt>1</tt>, <tt>2</tt> (always, automatic, never)</td>
+<td class="wiki">0.8.4+</td>
+</tr>
+<tr>
+<td class="wiki">scrollable</td>
+<td class="wiki">Scrolled window capability</td>
+<td class="wiki"><tt>true</tt> or <tt>false</tt></td>
+<td class="wiki">0.8.4+</td>
+</tr>
+<tr>
+<td class="wiki">height</td>
+<td class="wiki">Scrolled window dimension</td>
+<td class="wiki">An integer &gt; <tt>0</tt> or <tt>-1</tt> to ignore</td>
+<td class="wiki">0.8.4+</td>
+</tr>
+<tr>
+<td class="wiki">width</td>
+<td class="wiki">Scrolled window dimension</td>
+<td class="wiki">An integer &gt; <tt>0</tt> or <tt>-1</tt> to ignore</td>
+<td class="wiki">0.8.4+</td>
+</tr>
+<tr>
+<td class="wiki">shadow-type</td>
+<td class="wiki">Viewport shadow type</td>
+<td class="wiki"><tt>0</tt> to <tt>4</tt> (see <a href="http://developer-old.gnome.org/gtk2/2.24/gtk2-Standard-Enumerations.html#GtkShadowType">GtkShadowType</a>)</td>
+<td class="wiki">0.8.4+</td>
+</tr>
+<tr>
+<td class="wiki">scroll-to-bottom</td>
+<td class="wiki">Scroll to bottom on refresh</td>
+<td class="wiki"><tt>true</tt> or <tt>false</tt>
+<td class="wiki">0.8.4+</td>
+</tr>
 </tbody>
 </table>
 <h2 id="directives">Directives</h2>

--- a/examples/edit/edit_attributes
+++ b/examples/edit/edit_attributes
@@ -35,6 +35,20 @@ MAIN_DIALOG='
 			<width>350</width>
 			<default>cursor-visible is false</default>
 		</edit>
+		<edit scroll-to-bottom="true">
+			<variable>EDIT5</variable>
+			<height>50</height>
+			<width>350</width>
+			<default>"			1 top
+			2
+			3 scroll-to-bottom is true
+			4
+			5
+			6
+			7
+			8
+			9 bottom"</default>
+			</edit>
 		<hbox>
 			<button cancel></button>
 			<button ok></button>

--- a/examples/edit/edit_scrolling
+++ b/examples/edit/edit_scrolling
@@ -1,0 +1,39 @@
+#!/bin/sh
+
+[ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
+
+TMPD=/tmp/gtkdialog/examples/"`basename $0`"
+mkdir -p "$TMPD"
+max=10
+
+MAIN_DIALOG='
+<window>
+	<vbox>
+		<edit auto-refresh="true" scroll-to-bottom="true">
+			<input file>'"$TMPD/count$max"'</input>
+			<height>100</height>
+		</edit>
+		<hbox>
+			<button cancel></button>
+			<button ok></button>
+		</hbox>
+	</vbox>
+</window>
+'
+export MAIN_DIALOG
+
+case $1 in
+	-d | --dump) echo "$MAIN_DIALOG"; exit ;;
+esac
+
+(
+echo 'scroll-to-bottom="true"'
+for i in `seq $max`; do
+	sleep 1
+	echo $i of $max
+done
+echo done
+) > "$TMPD/count$max" &
+
+$GTKDIALOG --program=MAIN_DIALOG
+

--- a/examples/text/text_scrolling
+++ b/examples/text/text_scrolling
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+[ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
+
+TMPD=/tmp/gtkdialog/examples/"`basename $0`"
+mkdir -p "$TMPD"
+max=10
+
+MAIN_DIALOG='
+<window>
+	<vbox>
+		<hbox space-fill="true" space-expand="true">
+		<text auto-refresh="true" xalign="0" yalign="0"
+			wrap="false" use-markup="true"
+			scrollable="true" scroll-to-bottom="true"
+			width="500" height="100"
+			vscrollbar-policy="0" hscrollbar-policy="0"
+			shadow-type="0">
+			<input file>'"$TMPD/count$max"'</input>
+		</text>
+		</hbox>
+		<hbox>
+			<button cancel></button>
+			<button ok></button>
+		</hbox>
+	</vbox>
+</window>
+'
+export MAIN_DIALOG
+
+case $1 in
+	-d | --dump) echo "$MAIN_DIALOG"; exit ;;
+esac
+
+(
+echo '<b>scrollable="true" scroll-to-bottom="true" use-markup="true"</b>'
+for i in `seq $max`; do
+	sleep 1
+	echo "<b>$i</b> of $max"
+done
+echo "<b>done</b>"
+) > "$TMPD/count$max" &
+
+$GTKDIALOG --program=MAIN_DIALOG
+

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -23,6 +23,7 @@ gtkdialog_SOURCES = \
 	actions.c actions.h \
 	tag_attributes.c tag_attributes.h \
 	glade_support.c glade_support.h \
+	scrolling.c scrolling.h \
 	widget_button.c widget_button.h \
 	widget_checkbox.c widget_checkbox.h \
 	widget_colorbutton.c widget_colorbutton.h \

--- a/src/automaton.c
+++ b/src/automaton.c
@@ -753,6 +753,7 @@ static GtkWidget *put_in_the_scrolled_window(GtkWidget *widget,
 	switch (Type) {
 		case WIDGET_HBOX:
 		case WIDGET_VBOX:
+		case WIDGET_TEXT:
 			/* Get dimensions from custom tag attributes */
 			if (attr) {
 				if (value = get_tag_attribute(attr, "width"))
@@ -1205,7 +1206,18 @@ instruction_execute_push(
 			break;
 		case WIDGET_TEXT:
 			Widget = widget_text_create(Attr, tag_attributes, Widget_Type);
-			push_widget(Widget, Widget_Type);
+			/* step: If the custom attribute "scrollable" is true
+			 * then place the widget inside a GtkScrolledWindow */
+			if (tag_attributes &&
+				(value = get_tag_attribute(tag_attributes, "scrollable")) &&
+				((strcasecmp(value, "true") == 0) ||
+				(strcasecmp(value, "yes") == 0) || (atoi(value) == 1))) {
+				scrolled_window = put_in_the_scrolled_window(Widget, Attr,
+					tag_attributes, Widget_Type);
+				push_widget(scrolled_window, WIDGET_SCROLLEDW);
+			} else {
+				push_widget(Widget, Widget_Type);
+			}
 			break;
 		case WIDGET_TIMER:
 			Widget = widget_timer_create(Attr, tag_attributes, Widget_Type);

--- a/src/meson.build
+++ b/src/meson.build
@@ -13,6 +13,7 @@ src = [
 	'glade_support.c',
 	'gtkdialog.c',
 	'printing.c',
+	'scrolling.c',
 	'signals.c',
 	'stack.c',
 	'stringman.c',

--- a/src/scrolling.c
+++ b/src/scrolling.c
@@ -1,0 +1,97 @@
+/*
+ * scrolling.c: miscellaneous functions for scrollable widgets
+ * Gtkdialog - A small utility for fast and easy GUI building.
+ * Copyright (C) 2021       step https://github.com/step-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/* Includes */
+#define _GNU_SOURCE
+#include <gtk/gtk.h>
+#include "config.h"
+#include "gtkdialog.h"
+#include "attributes.h"
+#include "automaton.h"
+#include "widgets.h"
+#include "signals.h"
+#include "tag_attributes.h"
+#include "scrolling.h"
+
+/* Defines */
+//#define DEBUG_CONTENT
+//#define DEBUG_TRANSITS
+
+/* Local function prototypes, located at file bottom */
+static void scroll_value_changed (GtkAdjustment *adjustment, gpointer user_data);
+static void scroll_bottom_gravity (GtkWidget *scrolled_window,
+	GdkRectangle *allocation,
+	gpointer      user_data);
+
+/* Notes:
+ * step - scroll to bottom inspired by https://discourse.gnome.org/t/1337/2 */
+
+/***********************************************************************
+ * Scroll to Bottom
+ ***********************************************************************/
+
+void setup_scroll_to_bottom(variable *var)
+{
+	/* var->Widget being a scrollable widget can be scrolled to bottom */
+	GtkAdjustment *adjustment;
+	GtkWidget     *w;
+	gchar         *value;
+	double *from_bottom;
+
+	/* If the custom attribute "scroll-to-bottom" is true
+	 * then arrange for the scrollbar to scroll to bottom */
+	if (var->widget_tag_attr &&
+		(value = get_tag_attribute(var->widget_tag_attr, "scroll-to-bottom")) &&
+		((strcasecmp(value, "true") == 0) ||
+		(strcasecmp(value, "yes") == 0) || (atoi(value) == 1)) &&
+		(w = gtk_widget_get_ancestor(var->Widget, GTK_TYPE_SCROLLED_WINDOW)) &&
+		(from_bottom = g_slice_new0(double))) /* from_bottom is never freed */
+	{
+		/* store the scroll adjustment as heap data to be shared between the event handlers */
+		adjustment = gtk_scrolled_window_get_vadjustment(GTK_SCROLLED_WINDOW (w));
+		g_signal_connect(w, "size-allocate", (GCallback) scroll_bottom_gravity, from_bottom);
+		g_signal_connect(adjustment, "value-changed", (GCallback) scroll_value_changed, from_bottom);
+	}
+}
+
+/***********************************************************************
+ * Scroll to Bottom Callbacks                                          *
+ ***********************************************************************/
+static void scroll_value_changed (GtkAdjustment *adjustment, gpointer user_data)
+{
+	double *from_bottom = user_data;
+	double value = gtk_adjustment_get_value (adjustment);
+	double upper = gtk_adjustment_get_upper (adjustment);
+	double page_size = gtk_adjustment_get_page_size (adjustment);
+	*from_bottom = upper - page_size - value;
+}
+
+static void scroll_bottom_gravity (GtkWidget *scrolled_window,
+	GdkRectangle *allocation,
+	gpointer      user_data)
+{
+	GtkAdjustment *adjustment = gtk_scrolled_window_get_vadjustment (
+		GTK_SCROLLED_WINDOW (scrolled_window));
+	double *from_bottom = user_data;
+	double upper = gtk_adjustment_get_upper (adjustment);
+	double page_size = gtk_adjustment_get_page_size (adjustment);
+	gtk_adjustment_set_value (adjustment, upper - page_size - *from_bottom);
+}
+

--- a/src/scrolling.h
+++ b/src/scrolling.h
@@ -1,0 +1,27 @@
+/*
+ * scrolling.h: miscellaneous functions for scrollable widgets
+ * Gtkdialog - A small utility for fast and easy GUI building.
+ * Copyright (C) 2021       step https://github.com/step-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef SCROLLING_H
+#define SCROLLING_H
+
+/* Function prototypes */
+void setup_scroll_to_bottom(variable *var);
+
+#endif

--- a/src/widget_edit.c
+++ b/src/widget_edit.c
@@ -29,6 +29,7 @@
 #include "widgets.h"
 #include "signals.h"
 #include "tag_attributes.h"
+#include "scrolling.h"
 
 /* Defines */
 //#define DEBUG_CONTENT
@@ -229,6 +230,7 @@ void widget_edit_refresh(variable *var)
 
 		/* Connect signals */
 
+		setup_scroll_to_bottom(var);
 	}
 
 #ifdef DEBUG_TRANSITS

--- a/src/widget_text.c
+++ b/src/widget_text.c
@@ -29,6 +29,7 @@
 #include "widgets.h"
 #include "signals.h"
 #include "tag_attributes.h"
+#include "scrolling.h"
 
 /* Defines */
 //#define DEBUG_CONTENT
@@ -241,6 +242,8 @@ void widget_text_refresh(variable *var)
 			gtk_widget_set_sensitive(var->Widget, FALSE);
 
 		/* Connect signals */
+
+		setup_scroll_to_bottom(var);
 
 	}
 


### PR DESCRIPTION
This commit extends the custom attributes of text and edit widgets to
allow scrolling their content to the bottom when the widget is refreshed.
This allows "following" content updates if the widget is set to
auto-refresh - sort of like tail -f does.

Since the edit widget is scrollable by definition, just the new
scroll-to-bottom="true" custom attribute suffices to set the widget to
scroll on refresh.
The text widget takes on this new attribute, as well as the same group
of "scrolling" attributes that the vbox and hbox widgets define for
themselves.
The edit widget doesn't support pango markdown but the text widget does.

To see this new feature in action run the included example scripts.

Documentation updated. Note that I set the generic label "0.8.4+" as
the inception version of this feature.