### PR TITLE
extend inotify-based signals for gtk3

### DIFF
--- a/src/signals.h
+++ b/src/signals.h
@@ -80,7 +80,12 @@ void on_any_widget_row_activated_event(GtkWidget *widget,
 	GtkTreePath *path, GtkTreeViewColumn *column, AttributeSet *Attr);
 void on_any_widget_cursor_changed_event(GtkWidget *widget, AttributeSet *Attr);
 
-#if HAVE_SYS_INOTIFY_H
+#if HAVE_SYS_INOTIFY_H && GTK_CHECK_VERSION(3,0,0)
+gboolean on_any_widget_file_changed_event(GIOChannel *channel,
+	GIOCondition condition, gpointer data);
+gboolean on_any_widget_auto_refresh_event(GIOChannel *channel,
+	GIOCondition condition, gpointer data);
+#elif HAVE_SYS_INOTIFY_H
 void on_any_widget_file_changed_event(gpointer data, gint source,
 	GdkInputCondition condition);
 void on_any_widget_auto_refresh_event(gpointer data, gint source,

--- a/src/variables.c
+++ b/src/variables.c
@@ -91,7 +91,7 @@ void variables_print_one(variable *var)
 	fprintf(stderr, "Name: %s\n", var->Name);
 	fprintf(stderr, "  Widget: %p\n", var->Widget);
 	fprintf(stderr, "  Type: %s\n", widgets_to_str(var->Type));
-	fprintf(stderr, "  Parent: %p\n", var->ParentWindow);
+	fprintf(stderr, "  WindowId: %d\n", var->window_id);
 	fflush(stderr);
 }
 #endif

--- a/src/variables.h
+++ b/src/variables.h
@@ -60,6 +60,7 @@ variable *variables_hide(const char *name);
 variable *variables_activate(const char *name);
 variable *variables_grabfocus(const char *name);
 variable *variables_presentwindow(const char *name);
+gboolean variables_is_avail_by_name(const char *name);
 variable *variables_get_by_name(const char *name);
 gint variables_count_widgets(void);
 void variables_drop_by_window_id(variable *actual, gint window_id);


### PR DESCRIPTION
This PR replaces #116.

This commit extends the signal handling code involved with "auto-refresh" and "file-monitor" custom attributes to make it compile and work with GTK+-3.

It also fixes several "implicit declaration" compiler warnings.

The following scripts are simple and effective tests for auto-refresh and file-monitor because they set up 100 watches. Make sure to test all eight combinations: {gtk2, gtk3} x {w/, w/o inotify} x {auto-refresh, file-monitor}:
- examples/pixmap/pixmap_auto_refresh
- examples/pixmap/pixmap_file_monitor