### PR TITLE
fix some HTML reference pages

### DIFF
--- a/doc/reference/button.html
+++ b/doc/reference/button.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>button widget</h1>
@@ -104,7 +104,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkButton.html#GtkButton.object-hierarchy">GtkButton</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki">Name</th>
 <th class="wiki">Description</th>
@@ -170,7 +170,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -301,7 +301,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -354,7 +354,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -402,7 +402,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -527,7 +527,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/checkbox.html
+++ b/doc/reference/checkbox.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>checkbox widget</h1>
@@ -103,7 +103,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCheckButton.html#GtkCheckButton.object-hierarchy">GtkCheckButton</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -145,7 +145,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -270,7 +270,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -335,7 +335,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -383,7 +383,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -505,7 +505,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/colorbutton.html
+++ b/doc/reference/colorbutton.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>colorbutton widget</h1>
@@ -102,7 +102,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html#GtkColorButton.object-hierarchy">GtkColorButton</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -144,7 +144,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -263,7 +263,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -322,7 +322,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -370,7 +370,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -493,7 +493,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/combobox.html
+++ b/doc/reference/combobox.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>combobox widget</h1>
@@ -98,7 +98,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCombo.html#GtkCombo.object-hierarchy">GtkCombo</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -128,7 +128,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -192,7 +192,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -239,7 +239,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -287,7 +287,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -408,7 +408,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/comboboxentry.html
+++ b/doc/reference/comboboxentry.html
@@ -156,7 +156,7 @@
 <tr>
 <td class="wiki">fs-filters-mime</td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">common types</a>)</td>
+<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>

--- a/doc/reference/comboboxentry.html
+++ b/doc/reference/comboboxentry.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>comboboxentry widget</h1>
@@ -103,7 +103,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkComboBoxEntry.html#GtkComboBoxEntry.object-hierarchy">GtkComboBoxEntry</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -175,7 +175,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -301,7 +301,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -372,7 +372,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -420,7 +420,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -543,7 +543,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/comboboxtext.html
+++ b/doc/reference/comboboxtext.html
@@ -156,7 +156,7 @@
 <tr>
 <td class="wiki">fs-filters-mime</td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">common types</a>)</td>
+<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>

--- a/doc/reference/comboboxtext.html
+++ b/doc/reference/comboboxtext.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>comboboxtext widget</h1>
@@ -103,7 +103,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkComboBox.html#GtkComboBox.object-hierarchy">GtkComboBox</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -175,7 +175,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -300,7 +300,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -371,7 +371,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -419,7 +419,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -539,7 +539,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/edit.html
+++ b/doc/reference/edit.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>edit widget</h1>
@@ -101,7 +101,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkTextView.html#GtkTextView.object-hierarchy">GtkTextView</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -161,7 +161,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -250,7 +250,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -315,7 +315,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -363,7 +363,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -485,7 +485,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/entry.html
+++ b/doc/reference/entry.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10">
 					<tr>
 						<td>
 <h1>entry widget</h1>
@@ -104,7 +104,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry.object-hierarchy">GtkEntry</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -157,7 +157,7 @@
 <tr>
 <td class="wiki">fs-filters-mime</td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">common types</a>)</td>
+<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki">0.7.21</td>
 </tr>
 <tr>
@@ -176,7 +176,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -309,7 +309,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -386,7 +386,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -434,7 +434,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -554,7 +554,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0px" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/entry.html
+++ b/doc/reference/entry.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>entry widget</h1>
@@ -554,7 +554,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/eventbox.html
+++ b/doc/reference/eventbox.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>eventbox widget</h1>
@@ -97,7 +97,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkEventBox.html#GtkEventBox.object-hierarchy">GtkEventBox</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -127,7 +127,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -185,7 +185,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -220,7 +220,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -268,7 +268,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -389,7 +389,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/expander.html
+++ b/doc/reference/expander.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>expander widget</h1>
@@ -103,7 +103,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkExpander.html#GtkExpander.object-hierarchy">GtkExpander</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -145,7 +145,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -264,7 +264,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -323,7 +323,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -371,7 +371,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -495,7 +495,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/fontbutton.html
+++ b/doc/reference/fontbutton.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>fontbutton widget</h1>
@@ -102,7 +102,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFontButton.html#GtkFontButton.object-hierarchy">GtkFontButton</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -144,7 +144,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -263,7 +263,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -322,7 +322,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -370,7 +370,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -490,7 +490,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/frame.html
+++ b/doc/reference/frame.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>frame widget</h1>
@@ -104,7 +104,7 @@
 <p>None.</p>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -186,7 +186,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -239,7 +239,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -287,7 +287,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -407,7 +407,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/hbox.html
+++ b/doc/reference/hbox.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>hbox widget</h1>
@@ -99,7 +99,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHBox.html#GtkHBox.object-hierarchy">GtkHBox</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -165,7 +165,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -235,7 +235,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -270,7 +270,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -318,7 +318,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -442,7 +442,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/hscale.html
+++ b/doc/reference/hscale.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>hscale widget</h1>
@@ -103,7 +103,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHScale.html#GtkHScale.object-hierarchy">GtkHScale</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -169,7 +169,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -294,7 +294,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -347,7 +347,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -395,7 +395,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -518,7 +518,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/hseparator.html
+++ b/doc/reference/hseparator.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>hseparator widget</h1>
@@ -93,7 +93,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHSeparator.html#GtkHSeparator.object-hierarchy">GtkHSeparator</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -166,7 +166,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/list.html
+++ b/doc/reference/list.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>list widget</h1>
@@ -105,7 +105,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkList.html#GtkList.object-hierarchy">GtkList</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -171,7 +171,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -296,7 +296,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -355,7 +355,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -403,7 +403,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -527,7 +527,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/menu.html
+++ b/doc/reference/menu.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>menu widget</h1>
@@ -104,7 +104,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html#GtkMenuItem.object-hierarchy">GtkMenuItem</a> or <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImageMenuItem.html#GtkImageMenuItem.object-hierarchy">GtkImageMenuItem</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -152,7 +152,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -271,7 +271,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -318,7 +318,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -366,7 +366,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -489,7 +489,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/menubar.html
+++ b/doc/reference/menubar.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>menubar widget</h1>
@@ -97,7 +97,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuBar.html#GtkMenuBar.object-hierarchy">GtkMenuBar</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -127,7 +127,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -185,7 +185,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -220,7 +220,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -268,7 +268,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -388,7 +388,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/menuitem.html
+++ b/doc/reference/menuitem.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>menuitem widget</h1>
@@ -104,7 +104,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html#GtkMenuItem.object-hierarchy">GtkMenuItem</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/gtk2-gtkcheckmenuitem.html#gtk-gtkcheckmenuitem.object-hierarchy">GtkCheckMenuItem</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkRadioMenuItem.html#GtkRadioMenuItem.object-hierarchy">GtkRadioMenuItem</a> or <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImageMenuItem.html#GtkImageMenuItem.object-hierarchy">GtkImageMenuItem</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -176,7 +176,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -308,7 +308,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -361,7 +361,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -409,7 +409,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -534,7 +534,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/menuitemseparator.html
+++ b/doc/reference/menuitemseparator.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>menuitemseparator widget</h1>
@@ -141,7 +141,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/notebook.html
+++ b/doc/reference/notebook.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>notebook widget</h1>
@@ -100,7 +100,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkNotebook.html#GtkNotebook.object-hierarchy">GtkNotebook</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -166,7 +166,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -243,7 +243,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -296,7 +296,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -344,7 +344,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -466,7 +466,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/pixmap.html
+++ b/doc/reference/pixmap.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>pixmap widget</h1>
@@ -101,7 +101,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImage.html#GtkImage.object-hierarchy">GtkImage</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -155,7 +155,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -244,7 +244,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -285,7 +285,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -333,7 +333,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -456,7 +456,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/progressbar.html
+++ b/doc/reference/progressbar.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>progressbar widget</h1>
@@ -99,7 +99,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkProgressBar.html#GtkProgressBar.object-hierarchy">GtkProgressBar</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -129,7 +129,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -229,7 +229,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -252,7 +252,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -300,7 +300,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -420,7 +420,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/radiobutton.html
+++ b/doc/reference/radiobutton.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>radiobutton widget</h1>
@@ -103,7 +103,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkRadioButton.html#GtkRadioButton.object-hierarchy">GtkRadioButton</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -145,7 +145,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -270,7 +270,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -335,7 +335,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -383,7 +383,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -505,7 +505,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/separator.html
+++ b/doc/reference/separator.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>separator widget</h1>
@@ -135,7 +135,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/spinbutton.html
+++ b/doc/reference/spinbutton.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>spinbutton widget</h1>
@@ -102,7 +102,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkSpinButton.html#GtkSpinButton.object-hierarchy">GtkSpinButton</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -168,7 +168,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -290,7 +290,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -349,7 +349,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -397,7 +397,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -517,7 +517,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/statusbar.html
+++ b/doc/reference/statusbar.html
@@ -154,7 +154,7 @@
 <tr>
 <td class="wiki">fs-filters-mime</td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">common types</a>)</td>
+<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>

--- a/doc/reference/statusbar.html
+++ b/doc/reference/statusbar.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>statusbar widget</h1>
@@ -101,7 +101,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkStatusbar.html#GtkStatusbar.object-hierarchy">GtkStatusbar</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -173,7 +173,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -256,7 +256,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -315,7 +315,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -363,7 +363,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -483,7 +483,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/table.html
+++ b/doc/reference/table.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>table widget</h1>
@@ -106,7 +106,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCList.html#GtkCList.object-hierarchy">GtkCList</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -208,7 +208,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -345,7 +345,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -410,7 +410,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -458,7 +458,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -582,7 +582,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/terminal.html
+++ b/doc/reference/terminal.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>terminal widget</h1>
@@ -102,7 +102,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/vte/unstable/VteTerminal.html#VteTerminal.object-hierarchy">VteTerminal</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -216,7 +216,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -335,7 +335,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -388,7 +388,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -436,7 +436,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -561,7 +561,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/text.html
+++ b/doc/reference/text.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>text widget</h1>
@@ -99,7 +99,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkLabel.html#GtkLabel.object-hierarchy">GtkLabel</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -183,7 +183,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -260,7 +260,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -313,7 +313,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -361,7 +361,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -481,7 +481,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/timer.html
+++ b/doc/reference/timer.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>timer widget</h1>
@@ -100,7 +100,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget.properties">GtkWidget</a> widget properties<sup>[1]</sup>.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -142,7 +142,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -249,7 +249,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -290,7 +290,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -338,7 +338,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -463,7 +463,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/togglebutton.html
+++ b/doc/reference/togglebutton.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>togglebutton widget</h1>
@@ -106,7 +106,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html#GtkToggleButton.object-hierarchy">GtkToggleButton</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -172,7 +172,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -315,7 +315,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -368,7 +368,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -416,7 +416,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -543,7 +543,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/tree.html
+++ b/doc/reference/tree.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>tree widget</h1>
@@ -111,7 +111,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkTreeView.html#GtkTreeView.object-hierarchy">GtkTreeView</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -249,7 +249,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -424,7 +424,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -489,7 +489,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -537,7 +537,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -660,7 +660,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/vbox.html
+++ b/doc/reference/vbox.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>vbox widget</h1>
@@ -99,7 +99,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVBox.html#GtkVBox.object-hierarchy">GtkVBox</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -165,7 +165,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -235,7 +235,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -270,7 +270,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -318,7 +318,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -442,7 +442,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/vscale.html
+++ b/doc/reference/vscale.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>vscale widget</h1>
@@ -103,7 +103,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVScale.html#GtkVScale.object-hierarchy">GtkVScale</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -169,7 +169,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -294,7 +294,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -347,7 +347,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -395,7 +395,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -518,7 +518,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/vseparator.html
+++ b/doc/reference/vseparator.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>vseparator widget</h1>
@@ -93,7 +93,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVSeparator.html#GtkVSeparator.object-hierarchy">GtkVSeparator</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -166,7 +166,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>

--- a/doc/reference/window.html
+++ b/doc/reference/window.html
@@ -76,11 +76,11 @@
 </head>
 <body bgcolor="#e0e0e8">
 
-<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">-->
-	<table bgcolor="#b8b8c0" cellpadding="0px" cellspacing="1px">
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
 		<tr>
 			<td>
-				<table bgcolor="#ffffff" cellpadding="0px" cellspacing="10px">
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
 					<tr>
 						<td>
 <h1>window widget</h1>
@@ -101,7 +101,7 @@
 <h2 id="tag-attributes">Tag Attributes</h2>
 <p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWindow.html#GtkWindow.object-hierarchy">GtkWindow</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -155,7 +155,7 @@
 </table>
 <h2 id="directives">Directives</h2>
 <p>Some of these may have tag attribute equivalents.</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Name</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -238,7 +238,7 @@
 <p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -291,7 +291,7 @@
 </tbody>
 </table>
 <p>The following general functions can be performed by any widget capable of emitting signals:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -339,7 +339,7 @@
 </table>
 <h2 id="conditions">Conditions</h2>
 <p>The following conditions can be used within the condition attribute of action directives:</p>
-<table class="wiki" border="1" cellpadding="5px">
+<table class="wiki" border="1" cellpadding="5">
 <tr>
 <th class="wiki"><strong>Type</strong></th>
 <th class="wiki"><strong>Description</strong></th>
@@ -470,7 +470,7 @@
 					</tr>
 					<tr>
 						<td>
-							<table width="100%" cellpadding="0px" cellspacing="0px">
+							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
 									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
 									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>


### PR DESCRIPTION
Note that most HTML pages still include invalid cellpadding and cellspacing values - you need to delete "px" as shown in entry.html.

P.S. I have more significant PRs to come soon.