### PR TITLE
feature: new chooser widget

### DIFF
--- a/doc/reference/chooser.html
+++ b/doc/reference/chooser.html
@@ -1,0 +1,489 @@
+<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
+	"http://www.w3.org/TR/html4/loose.dtd">
+
+<html>
+<head>
+
+<title>gtkdialog: chooser widget reference</title>
+
+<meta http-equiv="content-type" content="text/html; charset=UTF-8" >
+
+<style type="text/css">
+	body {
+		font-size: 14px;
+		font-family: arial, verdana, sans-serif;
+		background-color: #e0e0e8;
+	}
+	h1 {
+		font-size: 24px;
+	}
+	h2 {
+		font-size: 18px;
+	}
+	a:link {
+		text-decoration: none;
+	}
+	a:visited {
+		text-decoration: none;
+	}
+	a:active {
+		text-decoration: none;
+	}
+	a:hover {
+		color: #8080ff;
+		text-decoration: underline;
+	}
+	hr {
+		color: #a8a8b0;
+		background-color: #a8a8b0;
+		height: 1px;
+		border: 0;
+	}
+	pre {
+		background-color: #e8e8f0;
+		/*width: 500px;*/
+		border: 1px dotted #b8b8c0;
+		padding: 10px;
+	}
+	tt  {
+		background-color: #e8e8f0
+	}
+	sup {
+		font-size: 10px;
+	}
+	table.wiki {
+		/*border-color: #ff0000;*/
+		border-color: #c8c8d0;
+		border-width: 0px 0px 2px 2px;
+		border-style: solid;
+		border-collapse: collapse;
+		border-spacing: 0px;
+	}
+	td.wiki, th.wiki {
+		/*border-color: #00ff00;*/
+		border-color: #c8c8d0;
+		border-width: 2px 2px 0px 0px;
+		border-style: solid;
+	}
+	th.wiki {
+		background-color: #e8e8f0;
+	}
+	.footer {
+		font-size: 14px;
+	}
+</style>
+
+</head>
+<body bgcolor="#e0e0e8">
+
+<!--<table width="978" align="center" bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">-->
+	<table bgcolor="#b8b8c0" cellpadding="0" cellspacing="1">
+		<tr>
+			<td>
+				<table bgcolor="#ffffff" cellpadding="0" cellspacing="10">
+					<tr>
+						<td>
+<h1>chooser widget</h1>
+<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html">GtkFileChooser</a></p>
+<hr>
+<h2>Definition</h2>
+<pre><code>&lt;chooser tag_attr=&quot;value&quot;...&gt;
+    &lt;default&gt;state&lt;/default&gt;
+    &lt;variable&gt;varname&lt;/variable&gt;
+    &lt;height&gt;value&lt;/height&gt;
+    &lt;width&gt;value&lt;/width&gt;
+    &lt;sensitive&gt;state&lt;/sensitive&gt;
+    &lt;input&gt;command&lt;/input&gt;
+    &lt;input file&gt;filename&lt;/input&gt;
+    &lt;action signal=&quot;type&quot;&gt;activity&lt;/action&gt;...
+    &lt;output file&gt;filename&lt;/output&gt;
+&lt;/chooser&gt;</code></pre>
+<p>“…” denotes acceptance of multiples of the same thing.</p>
+<h2 id="tag-attributes">Tag Attributes</h2>
+<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html#GtkFileChooser.object-hierarchy">GtkFileChooser</a> widget and ancestor class properties.</p>
+<p>The following custom tag attributes are available:</p>
+<table class="wiki" border="1" cellpadding="5">
+<tr>
+<th class="wiki"><strong>Name</strong></th>
+<th class="wiki"><strong>Description</strong></th>
+<th class="wiki"><strong>Value</strong></th>
+<th class="wiki"><strong>Since</strong></th>
+</tr>
+<tbody>
+<tr>
+<td class="wiki">block-function-signals</td>
+<td class="wiki">Block signal emissions from functions</td>
+<td class="wiki"><tt>true</tt> or <tt>false</tt></td>
+<td class="wiki">0.7.21</td>
+</tr>
+</tbody>
+</table>
+<h2 id="directives">Directives</h2>
+<p>Some of these may have tag attribute equivalents.</p>
+<table class="wiki" border="1" cellpadding="5">
+<tr>
+<th class="wiki"><strong>Name</strong></th>
+<th class="wiki"><strong>Description</strong></th>
+<th class="wiki"><strong>Contents</strong></th>
+<th class="wiki"><strong>Since</strong></th>
+</tr>
+<tbody>
+<tr>
+<td class="wiki">default</td>
+<td class="wiki">Initial directory</td>
+<td class="wiki"></td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">variable</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">variable export=“false”</td>
+<td class="wiki">Variable name, not exported to shell</td>
+<td class="wiki"></td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">height<sup>[1]</sup></td>
+<td class="wiki">Initial minimum height</td>
+<td class="wiki">An integer &gt; <tt>0</tt> or <tt>-1</tt> to ignore</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">width<sup>[1]</sup></td>
+<td class="wiki">Initial minimum width</td>
+<td class="wiki">An integer &gt; <tt>0</tt> or <tt>-1</tt> to ignore</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">sensitive</td>
+<td class="wiki">Sensitive state</td>
+<td class="wiki"><tt>true</tt> or <tt>false</tt></td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">input<sup>[2]</sup></td>
+<td class="wiki">Data input source</td>
+<td class="wiki">Shell command</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">input file<sup>[2]</sup></td>
+<td class="wiki">Data input source</td>
+<td class="wiki">Filename</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">action signal=“<em>type</em>”</td>
+<td class="wiki">Execute command on signal</td>
+<td class="wiki">Shell command</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">action signal=“<em>type</em>”</td>
+<td class="wiki">Perform function on signal</td>
+<td class="wiki"><em>function</em>:<em>parameter</em></td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">action signal=“<em>type</em>” condition=“<em>type</em>”</td>
+<td class="wiki">Execute command on signal conditionally</td>
+<td class="wiki">Shell command</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">action signal=“<em>type</em>” condition=“<em>type</em>”</td>
+<td class="wiki">Perform function on signal conditionally</td>
+<td class="wiki"><em>function</em>:<em>parameter</em></td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">output file<sup>[2]</sup></td>
+<td class="wiki">Data output target</td>
+<td class="wiki">Filename</td>
+<td class="wiki"></td>
+</tr>
+</tbody>
+</table>
+<h2 id="signals">Signals</h2>
+<p>The default signal is "<a href="https://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html#GtkFileChooser-file-activated">file-activated</a> emitted when the user "activates" a file in the file chooser. This can happen by double-clicking on a file in the file list, or by pressing Enter.</p>
+<p>The "selection-changed" signal is emitted when there is a change in the set of selected files in the file list.</p>
+<p>The "update-preview" signal is emitted when the preview in a file chooser should be regenerated. For example, this can happen when the currently selected file changes. This signal is still emitted even though the current implementation does not display a preview of the selected file.</p>
+<p>The "current-folder-changed" signal is emitted when the current folder in a chooser widget changes.</p>
+<p>The "confirm-overwrite" signal is emitted whenever it would be appropriate to present a confirmation dialog when the user has selected a file name that already exists. The current implementation never emits this signal.</p>
+<p>The following signals are connected-up for all widgets:</p>
+<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>,
+<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<h2 id="functions">Functions</h2>
+<p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
+<table class="wiki" border="1" cellpadding="5">
+<tr>
+<th class="wiki"><strong>Type</strong></th>
+<th class="wiki"><strong>Description</strong></th>
+<th class="wiki"><strong>Parameter</strong></th>
+<th class="wiki"><strong>Since</strong></th>
+</tr>
+<tbody>
+<tr>
+<td class="wiki">enable</td>
+<td class="wiki">Sensitise widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">disable</td>
+<td class="wiki">Desensitise widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">show</td>
+<td class="wiki">Show widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.1</td>
+</tr>
+<tr>
+<td class="wiki">hide</td>
+<td class="wiki">Hide widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.1</td>
+</tr>
+<tr>
+<td class="wiki">grabfocus</td>
+<td class="wiki">Grab input focus</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.1</td>
+</tr>
+<tr>
+<td class="wiki">refresh</td>
+<td class="wiki">Reload input data</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">save</td>
+<td class="wiki">Save widget data</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">clear</td>
+<td class="wiki">Remove all widget data</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">removeselected</td>
+<td class="wiki">Remove selected widget data</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+</tr>
+</tbody>
+</table>
+<p>The following general functions can be performed by any widget capable of emitting signals:</p>
+<table class="wiki" border="1" cellpadding="5">
+<tr>
+<th class="wiki"><strong>Type</strong></th>
+<th class="wiki"><strong>Description</strong></th>
+<th class="wiki"><strong>Parameter</strong></th>
+<th class="wiki"><strong>Since</strong></th>
+</tr>
+<tbody>
+<tr>
+<td class="wiki">break</td>
+<td class="wiki">Break out of actions list</td>
+<td class="wiki">None</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">command</td>
+<td class="wiki">Execute command</td>
+<td class="wiki">Shell command</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">exit</td>
+<td class="wiki">Exit dialog</td>
+<td class="wiki">A value for the <tt>EXIT</tt> variable</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">closewindow</td>
+<td class="wiki">Close dialog</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">launch</td>
+<td class="wiki">Launch dialog</td>
+<td class="wiki">Variable name</td>
+<td class="wiki"></td>
+</tr>
+<tr>
+<td class="wiki">presentwindow</td>
+<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.1</td>
+</tr>
+</tbody>
+</table>
+<h2 id="conditions">Conditions</h2>
+<p>The following conditions can be used within the condition attribute of action directives:</p>
+<table class="wiki" border="1" cellpadding="5">
+<tr>
+<th class="wiki"><strong>Type</strong></th>
+<th class="wiki"><strong>Description</strong></th>
+<th class="wiki"><strong>Argument</strong></th>
+<th class="wiki"><strong>Since</strong></th>
+</tr>
+<tbody>
+<tr>
+<td class="wiki">active_is_true(<em>argument</em>)</td>
+<td class="wiki">Active state of toggle widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">active_is_false(<em>argument</em>)</td>
+<td class="wiki">Active state of toggle widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">command_is_true(<em>argument</em>)</td>
+<td class="wiki">Output of shell command</td>
+<td class="wiki">Shell command</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">command_is_false(<em>argument</em>)</td>
+<td class="wiki">Output of shell command</td>
+<td class="wiki">Shell command</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">file_is_true(<em>argument</em>)</td>
+<td class="wiki">Contents of a file</td>
+<td class="wiki">Filename</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">file_is_false(<em>argument</em>)</td>
+<td class="wiki">Contents of a file</td>
+<td class="wiki">Filename</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">sensitive_is_true(<em>argument</em>)</td>
+<td class="wiki">Sensitive state of widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">sensitive_is_false(<em>argument</em>)</td>
+<td class="wiki">Sensitive state of widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">visible_is_true(<em>argument</em>)</td>
+<td class="wiki">Visible state of widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.3</td>
+</tr>
+<tr>
+<td class="wiki">visible_is_false(<em>argument</em>)</td>
+<td class="wiki">Visible state of widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.3</td>
+</tr>
+</tbody>
+</table>
+<p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
+<h2 id="notes">Notes</h2>
+<ol type="1">
+<li>This widget has no default dimensions. Use the <tt>height</tt> and/or <tt>width</tt> directives.</li>
+<li>For <tt>input</tt> and <tt>output</tt> directives the data is always a <u>file</u> file pathname, as you would set with the <tt>default-file</tt> custom tag.
+<li>The default file path takes precedence over the default directory. Versions &lt; 0.4.8+ ignore this custom tag.  Specify both the default file path and the default directory as a fall-back.</li>
+<li>Files that match <tt>fs-filters</tt> are listed after files that match <tt>fs-filters-mine</tt>.</li>
+</ol>
+<hr>
+<p>
+<a href="button.html">button</a>, 
+<a href="checkbox.html">checkbox</a>, 
+<a href="chooser.html">chooser</a>, 
+<a href="colorbutton.html">colorbutton</a>, 
+<a href="comboboxentry.html">comboboxentry</a>, 
+<a href="comboboxtext.html">comboboxtext</a>, 
+<a href="combobox.html">combobox</a>, 
+<a href="edit.html">edit</a>, 
+<a href="entry.html">entry</a>, 
+<a href="eventbox.html">eventbox</a>, 
+<a href="expander.html">expander</a>, 
+<a href="fontbutton.html">fontbutton</a>, 
+<a href="frame.html">frame</a>, 
+<a href="hbox.html">hbox</a>, 
+<a href="hscale.html">hscale</a>, 
+<a href="hseparator.html">hseparator</a>, 
+<a href="list.html">list</a>, 
+<a href="menubar.html">menubar</a>, 
+<a href="menuitemseparator.html">menuitemseparator</a>, 
+<a href="menuitem.html">menuitem</a>, 
+<a href="menu.html">menu</a>, 
+<a href="notebook.html">notebook</a>, 
+<a href="pixmap.html">pixmap</a>, 
+<a href="progressbar.html">progressbar</a>, 
+<a href="radiobutton.html">radiobutton</a>, 
+<a href="separator.html">separator</a>, 
+<a href="spinbutton.html">spinbutton</a>, 
+<a href="statusbar.html">statusbar</a>, 
+<a href="table.html">table</a>, 
+<a href="terminal.html">terminal</a>, 
+<a href="text.html">text</a>, 
+<a href="timer.html">timer</a>, 
+<a href="togglebutton.html">togglebutton</a>, 
+<a href="tree.html">tree</a>, 
+<a href="vbox.html">vbox</a>, 
+<a href="vscale.html">vscale</a>, 
+<a href="vseparator.html">vseparator</a>, 
+<a href="window.html">window</a>, 
+</p>
+
+							<p>&nbsp;</p>
+							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<table width="100%" cellpadding="0" cellspacing="0">
+								<tr>
+									<td class="footer" width="33%" align="center">2022-01-15 <a href="https:github.com/step-">step</a></td>
+									<td class="footer" width="33%" align="center"><a href="https://puppylinux-woof-CE/gtkdialog/">Project Page</a></td>
+									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+								</tr>
+							</table>
+						</td>
+					</tr>
+				</table>
+			</td>
+		</tr>
+	</table>
+
+</body>
+</html>
+

--- a/doc/reference/chooser.html
+++ b/doc/reference/chooser.html
@@ -430,6 +430,18 @@
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.3</td>
 </tr>
+<tr>
+<td class="wiki">variable_is_true(<em>argument</em>)</td>
+<td class="wiki">Value of widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.4+</td>
+</tr>
+<tr>
+<td class="wiki">variable_is_false(<em>argument</em>)</td>
+<td class="wiki">Value of widget</td>
+<td class="wiki">Variable name</td>
+<td class="wiki">0.8.4+</td>
+</tr>
 </tbody>
 </table>
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>

--- a/doc/reference/chooser.html
+++ b/doc/reference/chooser.html
@@ -84,7 +84,8 @@
 					<tr>
 						<td>
 <h1>chooser widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html">GtkFileChooser</a></p>
+<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooserWidget.html">GtkFileChooserWidget</a>
+that uses <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html">GtkFileChooser</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;chooser tag_attr=&quot;value&quot;...&gt;
@@ -100,7 +101,7 @@
 &lt;/chooser&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html#GtkFileChooser.object-hierarchy">GtkFileChooser</a> widget and ancestor class properties.</p>
+<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooserWidget.html#GtkFileChooserWidget.object-hierarchy">GtkFileChooserWidget</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>

--- a/doc/reference/chooser.html
+++ b/doc/reference/chooser.html
@@ -116,6 +116,24 @@
 <td class="wiki"><tt>true</tt> or <tt>false</tt></td>
 <td class="wiki">0.7.21</td>
 </tr>
+<tr>
+<td class="wiki">default-file<sup>[1]</sup></td>
+<td class="wiki">Initial file selection</td>
+<td class="wiki">A file absolute path</td>
+<td class="wiki">0.8.4+</td>
+</tr>
+<tr>
+<td class="wiki">fs-filters<sup>[2]</sup></td>
+<td class="wiki">fileselect function pattern file filters</td>
+<td class="wiki"><em>pattern</em><tt>|</tt><em>pattern</em><tt>|</tt>…</td>
+<td class="wiki">0.8.4+</td>
+</tr>
+<tr>
+<td class="wiki">fs-filters-mime<sup>[2]</sup></td>
+<td class="wiki">fileselect function mime-type file filters</td>
+<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
+<td class="wiki">0.8.4+</td>
+</tr>
 </tbody>
 </table>
 <h2 id="directives">Directives</h2>
@@ -131,7 +149,7 @@
 <tr>
 <td class="wiki">default</td>
 <td class="wiki">Initial directory</td>
-<td class="wiki"></td>
+<td class="wiki">A directory path, empty for the run directory</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -147,13 +165,13 @@
 <td class="wiki">0.8.3</td>
 </tr>
 <tr>
-<td class="wiki">height<sup>[1]</sup></td>
+<td class="wiki">height<sup>[3]</sup></td>
 <td class="wiki">Initial minimum height</td>
 <td class="wiki">An integer &gt; <tt>0</tt> or <tt>-1</tt> to ignore</td>
 <td class="wiki"></td>
 </tr>
 <tr>
-<td class="wiki">width<sup>[1]</sup></td>
+<td class="wiki">width<sup>[3]</sup></td>
 <td class="wiki">Initial minimum width</td>
 <td class="wiki">An integer &gt; <tt>0</tt> or <tt>-1</tt> to ignore</td>
 <td class="wiki"></td>
@@ -165,13 +183,13 @@
 <td class="wiki"></td>
 </tr>
 <tr>
-<td class="wiki">input<sup>[2]</sup></td>
+<td class="wiki">input<sup>[4]</sup></td>
 <td class="wiki">Data input source</td>
 <td class="wiki">Shell command</td>
 <td class="wiki"></td>
 </tr>
 <tr>
-<td class="wiki">input file<sup>[2]</sup></td>
+<td class="wiki">input file<sup>[4]</sup></td>
 <td class="wiki">Data input source</td>
 <td class="wiki">Filename</td>
 <td class="wiki"></td>
@@ -201,7 +219,7 @@
 <td class="wiki">0.8.3</td>
 </tr>
 <tr>
-<td class="wiki">output file<sup>[2]</sup></td>
+<td class="wiki">output file<sup>[4]</sup></td>
 <td class="wiki">Data output target</td>
 <td class="wiki">Filename</td>
 <td class="wiki"></td>
@@ -417,10 +435,10 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li>This widget has no default dimensions. Use the <tt>height</tt> and/or <tt>width</tt> directives.</li>
-<li>For <tt>input</tt> and <tt>output</tt> directives the data is always a <u>file</u> file pathname, as you would set with the <tt>default-file</tt> custom tag.
 <li>The default file path takes precedence over the default directory. Versions &lt; 0.4.8+ ignore this custom tag.  Specify both the default file path and the default directory as a fall-back.</li>
 <li>Files that match <tt>fs-filters</tt> are listed after files that match <tt>fs-filters-mine</tt>.</li>
+<li>This widget has no default dimensions. Use the <tt>height</tt> and/or <tt>width</tt> directives.</li>
+<li>For <tt>input</tt> and <tt>output</tt> directives data is always an absolute file path, as it can be set with the <tt>default-file</tt> custom tag.
 </ol>
 <hr>
 <p>

--- a/examples/chooser/chooser
+++ b/examples/chooser/chooser
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+# step 2022: This widget can be used to embed a file browsing section in a
+# larger dialog, for applications such as multi-type file viewers, e.g.
+# mm_view, and desktop wallpaper setters.  Unlike the fileselect function of
+# the entry widget, chooser does not have its own window, and only implements a
+# "file open" function, therefore there is no new directory creation button.
+# File filters are implemented.  Pretty much all standard gtkdialog 0.8.4
+# features are implemented, including signal chain handling with `signal` and
+# `condition` custom tags and function `break`, and <input> and <output> tags.
+# For compatibility with older scripts, the deprecated "when" custom tag is
+# supported by translation into the "signal" tag.
+
+[ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
+
+MAIN_DIALOG='
+<window title="Chooser 2022 Basic" resizable="false">
+	<vbox border-width="10">
+		<chooser>
+			<variable export="false">chooser</variable>
+			<default>/usr/share</default>
+			<width>600</width>
+			<height>400</height>
+			<sensitive>true</sensitive>
+			<action signal="current-folder-changed">echo current-folder-changed</action>
+			<action signal="file-activated">echo file-activated</action>
+			<action signal="selection-changed">echo selection-changed</action>
+			<action signal="update-preview">echo update-preview</action>
+		</chooser>
+		<hbox>
+			<button ok></button>
+			<button cancel></button>
+		</hbox>
+	</vbox>
+</window>
+'
+export MAIN_DIALOG
+
+case $1 in
+	-d | --dump) echo "$MAIN_DIALOG" ;;
+	*) $GTKDIALOG --program=MAIN_DIALOG ;;
+esac

--- a/examples/chooser/chooser_deprecated
+++ b/examples/chooser/chooser_deprecated
@@ -1,0 +1,1 @@
+../miscellaneous/chooser

--- a/examples/chooser/chooser_event_counters
+++ b/examples/chooser/chooser_event_counters
@@ -1,0 +1,100 @@
+#!/bin/sh
+
+# step 2021: The following new custom tag attributes, which
+# are ignored by older builds, gracefully degrade for backward compatibility.
+# "default-file"      overrides <default> - specify both if sensible
+# "fs-filters-mime"   like <entry>'s and listed before fs-filters
+# "fs-filters"        like <entry>'s
+
+# step 2022: A warning about GTK2 vs GTK3 signal differences
+#
+# The GTK3 GtkFileChooser triggers the "selection-changed" and "update-preview"
+# signals differently than the GTK2 GtkFileChooser.  If you want your
+# application to work on both GTK2 and GTK3 use this script to study which
+# events trigger on GTK2 vs GTK3.  Test what happens on application start, on a
+# single change of selection, and on applying file filters (fs-filters and
+# fs-filters-mime).  For the first two cases, the difference between GTK2 and
+# GTK3 is small but for file filters it is huge.  Unlike GTK2, which does not
+# trigger events while the filter selector is updating the file list, GTK3
+# triggers a "selection-changed" and an "update-preview" for each new file that
+# enters the file list. Thus, using the GTK3 file filter in a directory that
+# contains thousands of files can result in your application having to process
+# thousands of actions and slowing down to a crawl while the file selector is
+# being applied.
+
+[ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
+
+[ -d "$1" ] && this="$1" ||
+	this="$(find "/usr/share/pixmaps" -maxdepth 1 -type f | shuf | head -1)"
+
+chooser_attrs="
+default-file=\"$this\"
+fs-filters-mime=\"image/*|image/jpeg|image/png|image/x-xpixmap|x-xpmi\"
+fs-filters=\"*|*.xpm|*.[n-z]*|[a-m]*\"
+"
+
+MAIN_DIALOG='
+<window title="Chooser 2022 Event Counters" resizable="true">
+	<vbox border-width="10">
+		<chooser '"$chooser_attrs"'>
+			<variable>CHOOSER</variable>
+			<default>'"$(dirname "$this")"'</default>
+			<width>600</width>
+			<height>400</height>
+
+			<action signal="selection-changed">refresh:SELECTION_CHANGED</action>
+			<action signal="update-preview">refresh:UPDATE_PREVIEW</action>
+			<action signal="current-folder-changed">refresh:CURRENT_FOLDER_CHANGED</action>
+			<action signal="file-activated">refresh:FILE_ACTIVATED</action>
+			<action signal="button-release-event">refresh:BUTTON_RELEASE_EVENT</action>
+
+			<action signal="button-release-event">echo "button-release-event $CHOOSER"</action>
+			<action signal="current-folder-changed">echo "current-folder-changed $CHOOSER"</action>
+			<action signal="file-activated">echo "file-activated $CHOOSER"</action>
+			<action signal="selection-changed">echo "selection-changed $CHOOSER"</action>
+			<action signal="update-preview">echo "update-preview $CHOOSER"</action>
+		</chooser>
+		<frame Event counters>
+			<hbox homogeneous="true">
+				<text label="selection changed"></text>
+				<text label="update preview"></text>
+				<text label="current folder changed"></text>
+				<text label="file activated"></text>
+				<text label="button release event"></text>
+			</hbox>
+			<hbox homogeneous="true">
+				<text label="0">
+					<variable>SELECTION_CHANGED</variable>
+					<input>printf $(($SELECTION_CHANGED +1))</input>
+				</text>
+				<text label="0">
+					<variable>UPDATE_PREVIEW</variable>
+					<input>printf $(($UPDATE_PREVIEW +1))</input>
+				</text>
+				<text label="0">
+					<variable>CURRENT_FOLDER_CHANGED</variable>
+					<input>printf $(($CURRENT_FOLDER_CHANGED +1))</input>
+				</text>
+				<text label="0">
+					<variable>FILE_ACTIVATED</variable>
+					<input>printf $(($FILE_ACTIVATED +1))</input>
+				</text>
+				<text label="0">
+					<variable>BUTTON_RELEASE_EVENT</variable>
+					<input>printf $(($BUTTON_RELEASE_EVENT +1))</input>
+				</text>
+			</hbox>
+		</frame>
+		<hbox>
+			<button ok></button>
+			<button cancel></button>
+		</hbox>
+	</vbox>
+</window>
+'
+export MAIN_DIALOG
+
+case $1 in
+	-d | --dump) echo "$MAIN_DIALOG" ;;
+	*) $GTKDIALOG --program=MAIN_DIALOG ;;
+esac

--- a/examples/chooser/chooser_file_filters
+++ b/examples/chooser/chooser_file_filters
@@ -1,0 +1,44 @@
+#!/bin/sh
+
+# step 2022: The following new custom tag attributes, which
+# are ignored by older builds, gracefully degrade for backward compatibility.
+# "default-file"      overrides <default> - specify both if sensible
+# "fs-filters-mime"   like <entry>'s and listed before fs-filters
+# "fs-filters"        like <entry>'s
+		*/
+[ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
+
+this="$(find "/usr/share/pixmaps" -maxdepth 1 -type f | shuf | head -1)"
+
+chooser_attrs="
+default-file=\"$this\"
+fs-filters-mime=\"image/*|image/png|image/x-xpixmap|x-xpmi\"
+fs-filters=\"*|*.xpm|*.[n-z]*|[a-m]*\"
+"
+
+MAIN_DIALOG='
+<window title="Chooser 2022 File Filters" resizable="true">
+	<vbox border-width="10">
+		<chooser '"$chooser_attrs"'>
+			<variable>CHOOSER</variable>
+			<default>'"$(dirname "$this")"'</default>
+			<width>600</width>
+			<height>400</height>
+			<action when="current-folder-changed">echo "current-folder-changed $CHOOSER"</action>
+			<action when="file-activated">echo "file-activated $CHOOSER"</action>
+			<action when="selection-changed">echo "selection-changed $CHOOSER"</action>
+			<action when="update-preview">echo "update-preview $CHOOSER"</action>
+		</chooser>
+		<hbox>
+			<button ok></button>
+			<button cancel></button>
+		</hbox>
+	</vbox>
+</window>
+'
+export MAIN_DIALOG
+
+case $1 in
+	-d | --dump) echo "$MAIN_DIALOG" ;;
+	*) $GTKDIALOG --program=MAIN_DIALOG ;;
+esac

--- a/examples/chooser/chooser_in_out
+++ b/examples/chooser/chooser_in_out
@@ -1,0 +1,45 @@
+#!/bin/sh
+
+[ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
+
+TMPDIR="/tmp/gtkdialog/examples/${0##*/}"
+mkdir -p "$TMPDIR"
+printf "$(dirname "${TMPDIR%/*}")" > "$TMPDIR"/out_in
+
+MAIN_DIALOG='
+<window title="Chooser 2022 Input/Output" resizable="false">
+	<vbox border-width="10">
+		<text use-markup="true" label="<b><big>Top drives Bottom</big></b>"></text>
+		<text wrap="true" label="Change the file selection in the top file browser and watch how the file selection changes in the bottom browser too"></text>
+		<hseparator></hseparator>
+		<chooser>
+			<variable>TOP</variable>
+			<width>600</width>
+			<height>300</height>
+			<output file>'"$TMPDIR/out_in"'</output>
+			<action signal="update-preview">echo Top = $TOP</action>
+			<action signal="update-preview">save:TOP</action>
+			<action signal="update-preview">refresh:BOTTOM</action>
+		</chooser>
+		<hseparator></hseparator>
+		<chooser>
+			<variable>BOTTOM</variable>
+			<width>600</width>
+			<height>300</height>
+			<input file>'"$TMPDIR/out_in"'</input>
+			<action signal="selection-changed">echo Bottom = $BOTTOM</action>
+		</chooser>
+		<hseparator></hseparator>
+		<hbox>
+			<button ok></button>
+			<button cancel></button>
+		</hbox>
+	</vbox>
+</window>
+'
+export MAIN_DIALOG
+
+case $1 in
+	-d | --dump) echo "$MAIN_DIALOG" ;;
+	*) $GTKDIALOG --program=MAIN_DIALOG ;;
+esac

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -26,6 +26,7 @@ gtkdialog_SOURCES = \
 	scrolling.c scrolling.h \
 	widget_button.c widget_button.h \
 	widget_checkbox.c widget_checkbox.h \
+	widget_chooser.c widget_chooser.h \
 	widget_colorbutton.c widget_colorbutton.h \
 	widget_combobox.c widget_combobox.h \
 	widget_comboboxtext.c widget_comboboxtext.h \

--- a/src/automaton.c
+++ b/src/automaton.c
@@ -45,6 +45,7 @@
 #include "widgets.h"
 #include "widget_button.h"
 #include "widget_checkbox.h"
+#include "widget_chooser.h"
 #include "widget_colorbutton.h"
 #include "widget_combobox.h"
 #include "widget_comboboxtext.h"
@@ -963,68 +964,6 @@ create_gvim(AttributeSet * Attr)
 }
 #endif
 
-#if GTK_CHECK_VERSION(2,4,0)
-static GtkWidget *
-create_chooser(AttributeSet *Attr)
-{
-	GList     *element;
-	GtkWidget *chooser;
-	char      *act;
-	char      *tagattr_value;
-
-	PIP_DEBUG("");
-/*
-	GTK_FILE_CHOOSER_ACTION_OPEN	
-	Indicates open mode. The file chooser will only let the user
-	pick an existing file.
-
-	GTK_FILE_CHOOSER_ACTION_SAVE	
-	Indicates save mode. The file chooser will let the user pick
-	an existing file, or type in a new filename.
-
-	GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER	
-	Indicates an Open mode for selecting folders. The
-	file chooser will let the user pick an existing folder.
-
-	GTK_FILE_CHOOSER_ACTION_CREATE_FOLDER	
-	Indicates a mode for creating a new folder. The file
-	chooser will let the user name an existing or new folder.
-*/
-	chooser = gtk_file_chooser_widget_new(GTK_FILE_CHOOSER_ACTION_OPEN); 
-	if (attributeset_is_avail(Attr, ATTR_HEIGHT) &&
-	    attributeset_is_avail(Attr, ATTR_WIDTH))
-		/* gtk_widget_set_usize(chooser,	Redundant */
-		gtk_widget_set_size_request(chooser,
-				atoi(attributeset_get_first(&element, Attr, ATTR_WIDTH)),
-				atoi(attributeset_get_first(&element, Attr, ATTR_HEIGHT)));
-	
-	if (attributeset_is_avail(Attr, ATTR_DEFAULT))
-		gtk_file_chooser_set_current_folder((GtkFileChooser *)chooser, 
-				attributeset_get_first(&element, Attr, ATTR_DEFAULT));
-	
-	act = attributeset_get_first(&element, Attr, ATTR_ACTION);
-	while (act != NULL) {
-		tagattr_value = attributeset_get_this_tagattr(&element, Attr,
-			ATTR_ACTION, "when");
-		if (tagattr_value == NULL)
-			tagattr_value = "file-activated";
-		
-		/* gtk_signal_connect(GTK_OBJECT(chooser),
-				   tagattr_value,
-				   GTK_SIGNAL_FUNC
-				   (button_pressed), (gpointer) act);	Redundant */
-		g_signal_connect(G_OBJECT(chooser), tagattr_value,
-			G_CALLBACK(button_pressed),(gpointer)act);
-
-
-		act = attributeset_get_next(&element, Attr, ATTR_ACTION);
-	}
-
-	//gtk_file_chooser_set_preview_widget_active(chooser, TRUE);
-	return chooser;
-}
-#endif
-
 static gint 
 instruction_execute_push(
 		token          Token, 
@@ -1263,8 +1202,12 @@ instruction_execute_push(
 		/* Thunor: This widget is incredibly lacking in comparison to
 		 * the fileselect action function and really needs a newer
 		 * alternative (is anyone actually using this?) */
+
+		/* step 2022: This widget is used to embed a file-browsing
+		* GUI inside some file viewing applications, such as
+		* wallpaper setters and multi-type file viewers.  */
 #if GTK_CHECK_VERSION(2,4,0)
-		Widget = create_chooser(Attr);
+		Widget = widget_chooser_create(Attr, tag_attributes, Widget_Type);
 		push_widget(Widget, Widget_Type);
 #else
 		yyerror_simple("Chooser widget is not supported by"

--- a/src/meson.build
+++ b/src/meson.build
@@ -21,6 +21,7 @@ src = [
 	'variables.c',
 	'widget_button.c',
 	'widget_checkbox.c',
+	'widget_chooser.c',
 	'widget_colorbutton.c',
 	'widget_combobox.c',
 	'widget_comboboxtext.c',

--- a/src/signals.c
+++ b/src/signals.c
@@ -35,6 +35,7 @@
 #include "variables.h"
 #include "widget_button.h"
 #include "widget_checkbox.h"
+#include "widget_chooser.h"
 #include "widget_colorbutton.h"
 #include "widget_comboboxtext.h"
 #include "widget_edit.h"
@@ -206,17 +207,6 @@ void button_leaved_attr(GtkWidget *button, AttributeSet *Attr)
 #ifdef DEBUG_TRANSITS
 	fprintf(stderr, "%s(): Exiting.\n", __func__);
 #endif
-}
-
-/***********************************************************************
- *                                                                     *
- ***********************************************************************/
-
-/* Thunor: create_chooser() is now the only function calling this */
-
-void button_pressed(GtkWidget *button, const gchar *str)
-{
-	execute_action(GTK_WIDGET(button), str, NULL);
 }
 
 /***********************************************************************
@@ -1176,6 +1166,9 @@ void on_any_widget_auto_refresh_event(GFileMonitor *monitor, GFile *file,
 		case WIDGET_CHECKBOX:
 			widget_checkbox_refresh(var);
 			break;
+		case WIDGET_CHOOSER:
+			widget_chooser_refresh(var);
+			break;
 		case WIDGET_COLORBUTTON:
 			widget_colorbutton_refresh(var);
 			break;
@@ -1497,6 +1490,11 @@ void widget_signal_executor(GtkWidget *widget, AttributeSet *Attr,
 					execute = widget_signal_executor_eval_condition(condition);
 				}
 #endif
+/* GtkWidget--->GtkFileChooser */
+			} else if (GTK_IS_FILE_CHOOSER(widget)) {
+				if (strcasecmp(signal_name, "file-activated") == 0) {
+					execute = widget_signal_executor_eval_condition(condition);
+				}
 			}
 
 			/* Deal with toggle widgets here as they can have a conditional
@@ -2009,3 +2007,112 @@ void widget_file_monitor_try_create(variable *var, gchar *filename)
 	}
 }
 #endif
+
+/***********************************************************************
+ *                                                                     *
+ ***********************************************************************/
+
+void on_any_widget_file_activated_event(GtkWidget *widget, AttributeSet *Attr)
+{
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	widget_signal_executor(widget, Attr, "file-activated");
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ *                                                                     *
+ ***********************************************************************/
+
+void on_any_widget_current_folder_changed_event(GtkWidget *widget, AttributeSet *Attr)
+{
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	widget_signal_executor(widget, Attr, "current-folder-changed");
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Chooser                                                             *
+ ***********************************************************************/
+
+/* step 2022: Work-around for GTK+-3 GtkFileChooser duplicate events issue.
+ *
+ * The GTK3 file chooser widget triggers duplicate "selection-changed" and
+ * "update-preview" events.  Duplicates
+ * do not occur with the GTK2 file chooser.  I have implemented a work-around
+ * by defining a dedicated signal handling function for each of these two
+ * signals.  The handler calls widget_signal_executor only if the current
+ * widget data is non-empty and differs from the previous call, otherwise the
+ * executor isn't called.  Thus, a repeated sequence of the same file path hits
+ * execution only once, and never if the file path is empty.  This logic can
+ * only work because the signal executor handles all actions defined for a
+ * widget as a whole unit. It would not work with the older chooser
+ * implementation, which handled each <action when> independently of other
+ * actions.  Without this work-around, the demo script was showing literally
+ * thousands of duplicate or empty events when changing fs-filters in
+ * directory holding a large photo collection. The GTK2 file chooser benefits
+ * from this work-around too, because it is known to trigger signals when the
+ * file path is empty. */
+
+void on_chooser_widget_selection_changed_event(GtkWidget *widget, AttributeSet *Attr)
+{
+	variable        *var   = NULL;
+	static gchar    *prev  = NULL;
+	gchar           *value = NULL;
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	value = widget_get_text_value(widget, WIDGET_CHOOSER);
+	if (value && *value) {
+		if (!prev || strcmp(prev, value) != 0)
+			widget_signal_executor(widget, Attr, "selection-changed"); /* it really did */
+		if (prev)
+			g_free(prev);
+		prev = value;
+	}
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Chooser                                                             *
+ ***********************************************************************/
+
+void on_chooser_widget_update_preview_event(GtkWidget *widget, AttributeSet *Attr)
+{
+	variable        *var   = NULL;
+	static gchar    *prev  = NULL;
+	gchar           *value = NULL;
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	value = widget_get_text_value(widget, WIDGET_CHOOSER);
+	if (value && *value) {
+		if (!prev || strcmp(prev, value) != 0)
+			widget_signal_executor(widget, Attr, "update-preview"); /* it really did */
+		if (prev)
+			g_free(prev);
+		prev = value;
+	}
+
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+

--- a/src/signals.c
+++ b/src/signals.c
@@ -1490,8 +1490,8 @@ void widget_signal_executor(GtkWidget *widget, AttributeSet *Attr,
 					execute = widget_signal_executor_eval_condition(condition);
 				}
 #endif
-/* GIinterface--->GtkFileChooser */
-			} else if (GTK_IS_FILE_CHOOSER(widget)) {
+/* GtkWidget--->GtkContainer--->GtkBox--->GtkVBox--->GtkFileChooserWidget */
+			} else if (GTK_IS_FILE_CHOOSER_WIDGET(widget)) {
 				if (strcasecmp(signal_name, "file-activated") == 0) {
 					execute = widget_signal_executor_eval_condition(condition);
 				}

--- a/src/signals.c
+++ b/src/signals.c
@@ -2049,7 +2049,8 @@ void on_any_widget_current_folder_changed_event(GtkWidget *widget, AttributeSet 
 /* step 2022: Work-around for GTK+-3 GtkFileChooser duplicate events issue.
  *
  * The GTK3 file chooser widget triggers duplicate "selection-changed" and
- * "update-preview" events.  Duplicates
+ * "update-preview" events when fs-filters(-mime) is used to filter the file
+ * list. See demo script "examples/chooser/chooser_event_counters".  Duplicates
  * do not occur with the GTK2 file chooser.  I have implemented a work-around
  * by defining a dedicated signal handling function for each of these two
  * signals.  The handler calls widget_signal_executor only if the current

--- a/src/signals.c
+++ b/src/signals.c
@@ -1490,7 +1490,7 @@ void widget_signal_executor(GtkWidget *widget, AttributeSet *Attr,
 					execute = widget_signal_executor_eval_condition(condition);
 				}
 #endif
-/* GtkWidget--->GtkFileChooser */
+/* GIinterface--->GtkFileChooser */
 			} else if (GTK_IS_FILE_CHOOSER(widget)) {
 				if (strcasecmp(signal_name, "file-activated") == 0) {
 					execute = widget_signal_executor_eval_condition(condition);

--- a/src/signals.h
+++ b/src/signals.h
@@ -107,4 +107,8 @@ void widget_signal_executor(GtkWidget *widget, AttributeSet *Attr,
 	const gchar *signal_name);
 void widget_file_monitor_try_create(variable *var, gchar *filename);
 
+void on_any_widget_file_activated_event(GtkWidget *widget, AttributeSet *Attr);
+void on_any_widget_current_folder_changed_event(GtkWidget *widget, AttributeSet *Attr);
+void on_chooser_widget_selection_changed_event(GtkWidget *widget, AttributeSet *Attr);
+void on_chooser_widget_update_preview_event(GtkWidget *widget, AttributeSet *Attr);
 #endif

--- a/src/variables.c
+++ b/src/variables.c
@@ -25,6 +25,7 @@
 #include "widgets.h"
 #include "widget_button.h"
 #include "widget_checkbox.h"
+#include "widget_chooser.h"
 #include "widget_colorbutton.h"
 #include "widget_combobox.h"
 #include "widget_comboboxtext.h"
@@ -377,6 +378,9 @@ variable *variables_set_value(const char *name, const char *value)
 		case WIDGET_CHECKBOX:
 			widget_checkbox_fileselect(toset, name, value);
 			break;
+		case WIDGET_CHOOSER:
+			widget_chooser_fileselect(toset, name, value);
+			break;
 		case WIDGET_COLORBUTTON:
 			widget_colorbutton_fileselect(toset, name, value);
 			break;
@@ -503,6 +507,9 @@ variable *variables_save(const char *name)
 			break;
 		case WIDGET_CHECKBOX:
 			widget_checkbox_save(var);
+			break;
+		case WIDGET_CHOOSER:
+			widget_chooser_save(var);
 			break;
 		case WIDGET_COLORBUTTON:
 			widget_colorbutton_save(var);
@@ -650,6 +657,9 @@ variable *variables_refresh(const char *name)
 			break;
 		case WIDGET_CHECKBOX:
 			widget_checkbox_refresh(var);
+			break;
+		case WIDGET_CHOOSER:
+			widget_chooser_refresh(var);
 			break;
 		case WIDGET_COLORBUTTON:
 			widget_colorbutton_refresh(var);
@@ -1719,6 +1729,9 @@ variable *variables_clear(const char *name)
 		case WIDGET_CHECKBOX:
 			widget_checkbox_clear(toclear);
 			break;
+		case WIDGET_CHOOSER:
+			widget_chooser_clear(toclear);
+			break;
 		case WIDGET_COLORBUTTON:
 			widget_colorbutton_clear(toclear);
 			break;
@@ -1865,6 +1878,9 @@ int remove_selected_variable(const char *name)
 			break;
 		case WIDGET_CHECKBOX:
 			widget_checkbox_removeselected(toclear);
+			break;
+		case WIDGET_CHOOSER:
+			widget_chooser_removeselected(toclear);
 			break;
 		case WIDGET_COLORBUTTON:
 			widget_colorbutton_removeselected(toclear);

--- a/src/widget_chooser.c
+++ b/src/widget_chooser.c
@@ -286,11 +286,6 @@ void widget_chooser_refresh(variable *var)
 			* "fs-filters-mime"   like <entry>'s and listed before fs-filters
 			* "fs-filters"        like <entry>'s */
 
-			/*XXX step 2022: Unfortunately, GTK+-3 GtkFileChooser triggers the
-			* "selection-changed" and "update-preview" events more often than
-			* necessary when fs-filters(-mime) is used. This issue is further
-			* discussed in the sample scripts under "examples/chooser". */
-
 			/* Default file overrides <default> directory */
 			if ((tagattr_value = get_tag_attribute(var->widget_tag_attr, "default-file")))
 				gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(var->Widget), tagattr_value);

--- a/src/widget_chooser.c
+++ b/src/widget_chooser.c
@@ -1,0 +1,507 @@
+/*
+ * widget_chooser.c:
+ * Gtkdialog - A small utility for fast and easy GUI building.
+ * Copyright (C) 2003-2007  László Pere <pipas@linux.pte.hu>
+ * Copyright (C) 2011-2012  Thunor <thunorsif@hotmail.com>
+ * Copyright (C) 2021-2022  step https://github.com/step-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+/* Includes */
+#define _GNU_SOURCE
+#include <gtk/gtk.h>
+#include "config.h"
+#include "gtkdialog.h"
+#include "attributes.h"
+#include "automaton.h"
+#include "widgets.h"
+#include "signals.h"
+#include "tag_attributes.h"
+
+/* Defines */
+//#define DEBUG_CONTENT
+//#define DEBUG_TRANSITS
+
+/* Local function prototypes, located at file bottom */
+static void widget_chooser_input_by_command(variable *var, char *command);
+static void widget_chooser_input_by_file(variable *var, char *filename);
+static void widget_chooser_input_by_items(variable *var);
+
+/* Notes: */
+
+/***********************************************************************
+ * Clear                                                               *
+ ***********************************************************************/
+
+void widget_chooser_clear(variable *var)
+{
+	gchar            *var1;
+	gint              var2;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	/* step: effectively this sets the browsed-in folder to $PWD's parent */
+	gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(var->Widget), "");
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Create                                                              *
+ ***********************************************************************/
+
+GtkWidget *widget_chooser_create(
+	AttributeSet *Attr, tag_attr *attr, gint Type)
+{
+	GtkWidget       *widget;
+	GList           *element;
+	gchar           *act;
+	gchar           *tagattr_value;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+/*
+	step 2022: GTK_FILE_CHOOSER_ACTION_OPEN only is implemented.
+
+	GTK_FILE_CHOOSER_ACTION_OPEN
+	Indicates open mode. The file chooser will only let the user
+	pick an existing file.
+
+	GTK_FILE_CHOOSER_ACTION_SAVE
+	Indicates save mode. The file chooser will let the user pick
+	an existing file, or type in a new filename.
+
+	GTK_FILE_CHOOSER_ACTION_SELECT_FOLDER
+	Indicates an Open mode for selecting folders. The
+	file chooser will let the user pick an existing folder.
+
+	GTK_FILE_CHOOSER_ACTION_CREATE_FOLDER
+	Indicates a mode for creating a new folder. The file
+	chooser will let the user name an existing or new folder.
+*/
+	widget = gtk_file_chooser_widget_new(GTK_FILE_CHOOSER_ACTION_OPEN);
+
+	/* step: for backward-compatibility convert the deprecated signal
+	* attribute "when" to the new attribute "signal" so the
+	* widget_signal_executor can take care of it */
+
+	act = attributeset_get_first(&element, Attr, ATTR_ACTION);
+	while (act != NULL) {
+		tagattr_value = attributeset_get_this_tagattr(&element, Attr,
+			ATTR_ACTION, "when");
+
+		/* default signal */
+		if (tagattr_value == NULL)
+			tagattr_value = "file-activated";
+		else {
+			/* add "signal" while leaving "when" as is because
+			*  widget_signal_executor will just ignore "when" */
+			attributeset_set_this_tagattr(&element, Attr,
+				ATTR_ACTION, "signal", tagattr_value);
+			fprintf(stderr, "%s(): %s %s\n", __func__,
+				"Warning: action attribute \"when\" is deprecated.",
+				"Consider replacing \"when\" with \"signal\".\n");
+		}
+
+		act = attributeset_get_next(&element, Attr, ATTR_ACTION);
+	}
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+
+	return widget;
+}
+
+/***********************************************************************
+ * Environment Variable All Construct                                  *
+ ***********************************************************************/
+
+gchar *widget_chooser_envvar_all_construct(variable *var)
+{
+	gchar            *string;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	/* This function should not be connected-up by default */
+
+#ifdef DEBUG_CONTENT
+	fprintf(stderr, "%s(): Hello.\n", __func__);
+#endif
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+
+	return string;
+}
+
+/***********************************************************************
+ * Environment Variable Construct                                      *
+ ***********************************************************************/
+
+gchar *widget_chooser_envvar_construct(GtkWidget *widget)
+{
+	gchar            *string = NULL;
+	gchar            *text;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	text = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(widget));
+	if (text) {
+		string = g_strdup(text);
+		g_free(text);
+	}
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+
+	return string;
+}
+
+/***********************************************************************
+ * Fileselect                                                          *
+ ***********************************************************************/
+
+void widget_chooser_fileselect(
+	variable *var, const char *name, const char *value)
+{
+	gchar            *var1;
+	gint              var2;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	fprintf(stderr, "%s(): Fileselect not implemented for this widget.\n", __func__);
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Refresh                                                             *
+ ***********************************************************************/
+
+void widget_chooser_refresh(variable *var)
+{
+	GList           *element;
+	gchar           *act;
+	gint            initialised = FALSE;
+	gchar           *tagattr_value;
+	list_t          *mime_types = NULL;
+	list_t          *patterns = NULL;
+	gint            count;
+	GtkFileFilter   *filter;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	/* Get initialised state of widget */
+	if (g_object_get_data(G_OBJECT(var->Widget), "_initialised") != NULL)
+		initialised = (gint)g_object_get_data(G_OBJECT(var->Widget), "_initialised");
+
+	/* The <input> tag... */
+	act = attributeset_get_first(&element, var->Attributes, ATTR_INPUT);
+	while (act) {
+		if (input_is_shell_command(act))
+			widget_chooser_input_by_command(var, act + 8);
+		/* input file stock = "File:", input file = "File:/path/to/file" */
+		if (strncasecmp(act, "file:", 5) == 0 && strlen(act) > 5) {
+			if (!initialised) {
+				/* Check for file-monitor and create if requested */
+				widget_file_monitor_try_create(var, act + 5);
+			}
+			widget_chooser_input_by_file(var, act + 5);
+		}
+		act = attributeset_get_next(&element, var->Attributes, ATTR_INPUT);
+	}
+
+	/* The <item> tags... */
+	if (attributeset_is_avail(var->Attributes, ATTR_ITEM))
+		widget_chooser_input_by_items(var);
+
+	/* Initialise these only once at start-up */
+	if (!initialised) {
+		/* Apply directives */
+		if (attributeset_is_avail(var->Attributes, ATTR_LABEL))
+			fprintf(stderr, "%s(): <label> not implemented for this widget.\n",
+				__func__);
+
+		if (attributeset_is_avail(var->Attributes, ATTR_DEFAULT)) {
+			gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(var->Widget),
+				attributeset_get_first(&element, var->Attributes, ATTR_DEFAULT));
+		} else {
+			/* cwd */
+			gtk_file_chooser_set_current_folder(GTK_FILE_CHOOSER(var->Widget), "");
+		}
+
+		/* set either width or height or both from directives */
+		gtk_widget_set_size_request(var->Widget,
+			attributeset_is_avail(var->Attributes, ATTR_WIDTH)
+			? atoi(attributeset_get_first(&element, var->Attributes, ATTR_WIDTH))
+			: -1,
+			attributeset_is_avail(var->Attributes, ATTR_HEIGHT)
+			? atoi(attributeset_get_first(&element, var->Attributes, ATTR_HEIGHT))
+			: -1);
+
+		if ((attributeset_cmp_left(var->Attributes, ATTR_SENSITIVE, "false")) ||
+			(attributeset_cmp_left(var->Attributes, ATTR_SENSITIVE, "disabled")) ||	/* Deprecated */
+			(attributeset_cmp_left(var->Attributes, ATTR_SENSITIVE, "no")) ||
+			(attributeset_cmp_left(var->Attributes, ATTR_SENSITIVE, "0")))
+			gtk_widget_set_sensitive(var->Widget, FALSE);
+
+		//gtk_file_chooser_set_preview_widget_active(GTK_FILE_CHOOSER(var->Widget), TRUE);
+
+		if (var->widget_tag_attr) {
+			/* step 2021 New custom tag attributes:
+			* (older versions ignore them therefore degrade gracefully)
+			* "default-file"      overrides <default> - specify both if sensible
+			* "fs-filters-mime"   like <entry>'s and listed before fs-filters
+			* "fs-filters"        like <entry>'s */
+
+			/*XXX step 2022: Unfortunately, GTK+-3 GtkFileChooser triggers the
+			* "selection-changed" and "update-preview" events more often than
+			* necessary when fs-filters(-mime) is used. This issue is further
+			* discussed in the sample scripts under "examples/chooser". */
+
+			/* Default file overrides <default> directory */
+			if ((tagattr_value = get_tag_attribute(var->widget_tag_attr, "default-file")))
+				gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(var->Widget), tagattr_value);
+
+			/* File Filters of type mime are listed before pattern filters */
+			if ((tagattr_value = get_tag_attribute(var->widget_tag_attr, "fs-filters-mime"))) {
+				mime_types = linecutter(g_strdup(tagattr_value), '|');
+				for (count = 0; count < mime_types->n_lines; count++) {
+					filter = gtk_file_filter_new();
+					gtk_file_filter_set_name(filter, mime_types->line[count]);
+					gtk_file_filter_add_mime_type(filter, mime_types->line[count]);
+					gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(var->Widget), filter);
+				}
+				if (mime_types) list_t_free(mime_types);
+			}
+
+			/* File filters of type pattern are listed after mime-type filters */
+			if ((tagattr_value = get_tag_attribute(var->widget_tag_attr, "fs-filters"))) {
+				patterns = linecutter(g_strdup(tagattr_value), '|');
+				for (count = 0; count < patterns->n_lines; count++) {
+					filter = gtk_file_filter_new();
+					gtk_file_filter_set_name(filter, patterns->line[count]);
+					gtk_file_filter_add_pattern(filter, patterns->line[count]);
+					gtk_file_chooser_add_filter(GTK_FILE_CHOOSER(var->Widget), filter);
+				}
+				if (patterns) list_t_free(patterns);
+			}
+		}
+
+		/* Connect signals */
+
+		g_signal_connect(G_OBJECT(var->Widget), "file-activated",
+			G_CALLBACK(on_any_widget_file_activated_event), (gpointer)var->Attributes);
+		g_signal_connect(G_OBJECT(var->Widget), "selection-changed",
+			G_CALLBACK(on_chooser_widget_selection_changed_event), (gpointer)var->Attributes);
+		g_signal_connect(G_OBJECT(var->Widget), "update-preview",
+			G_CALLBACK(on_chooser_widget_update_preview_event), (gpointer)var->Attributes);
+		g_signal_connect(G_OBJECT(var->Widget), "current-folder-changed",
+			G_CALLBACK(on_any_widget_current_folder_changed_event), (gpointer)var->Attributes);
+		/* step: confirm-overwrite not implemented */
+	}
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Removeselected                                                      *
+ ***********************************************************************/
+
+void widget_chooser_removeselected(variable *var)
+{
+	gchar            *var1;
+	gint              var2;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	fprintf(stderr, "%s(): Removeselected not implemented for this widget.\n",
+		__func__);
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Save                                                                *
+ ***********************************************************************/
+
+void widget_chooser_save(variable *var)
+{
+	FILE             *outfile;
+	GList            *element;
+	GtkTextBuffer    *buffer;
+	GtkTextIter       start, end;
+	gchar            *act;
+	gchar            *filename = NULL;
+	gchar            *text;
+	gchar            *string;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	/* We'll use the output file filename if available */
+	act = attributeset_get_first(&element, var->Attributes, ATTR_OUTPUT);
+	while (act) {
+		if (strncasecmp(act, "file:", 5) == 0 && strlen(act) > 5) {
+			filename = act + 5;
+			break;
+		}
+		act = attributeset_get_next(&element, var->Attributes, ATTR_OUTPUT);
+	}
+
+	/* If we have a valid filename then open it and dump the widget's data to it */
+	if (filename) {
+		text = gtk_file_chooser_get_filename(GTK_FILE_CHOOSER(var->Widget));
+			if (text) {
+				string = g_strdup(text);
+				if ((outfile = fopen(filename, "w"))) {
+					fprintf(outfile, "%s", string);
+					fclose(outfile);
+				} else {
+					fprintf(stderr, "%s(): Couldn't open '%s' for writing.\n",
+						__func__, filename);
+				}
+				g_free(text);
+			}
+	} else {
+		fprintf(stderr, "%s(): No <output file> directive found.\n", __func__);
+	}
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Input by Command                                                    *
+ ***********************************************************************/
+
+static void widget_chooser_input_by_command(variable *var, char *command)
+{
+	FILE             *infile;
+	GString          *text = g_string_sized_new(512);
+	gchar             line[512];
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+#ifdef DEBUG_CONTENT
+	fprintf(stderr, "%s(): command: '%s'\n", __func__, command);
+#endif
+
+	/* Opening pipe for reading... */
+	if (infile = widget_opencommand(command)) {
+		/* Read the file one line at a time */
+		while (fgets(line, 512, infile)) {
+			g_string_append(text, line);
+		}
+
+		gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(var->Widget), text->str);
+		g_string_free(text, TRUE);
+
+		/* Close the file */
+		pclose(infile);
+	} else {
+		fprintf(stderr, "%s(): Couldn't open '%s' for reading.\n", __func__,
+			command);
+	}
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Input by File                                                       *
+ ***********************************************************************/
+
+static void widget_chooser_input_by_file(variable *var, char *filename)
+{
+	FILE             *infile;
+	GString          *text = g_string_sized_new(512);
+	gchar             line[512];
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	if (infile = fopen(filename, "r")) {
+		/* Read the file one line at a time */
+		while (fgets(line, 512, infile)) {
+			g_string_append(text, line);
+		}
+
+		gtk_file_chooser_set_filename(GTK_FILE_CHOOSER(var->Widget), text->str);
+		g_string_free(text, TRUE);
+
+		/* Close the file */
+		fclose(infile);
+	} else {
+		fprintf(stderr, "%s(): Couldn't open '%s' for reading.\n", __func__,
+			filename);
+	}
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}
+
+/***********************************************************************
+ * Input by Items                                                      *
+ ***********************************************************************/
+
+static void widget_chooser_input_by_items(variable *var)
+{
+	gchar            *var1;
+	gint              var2;
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Entering.\n", __func__);
+#endif
+
+	fprintf(stderr, "%s(): <item> not implemented for this widget.\n", __func__);
+
+#ifdef DEBUG_TRANSITS
+	fprintf(stderr, "%s(): Exiting.\n", __func__);
+#endif
+}

--- a/src/widget_chooser.h
+++ b/src/widget_chooser.h
@@ -1,0 +1,38 @@
+/*
+ * widget_chooser.h:
+ * Gtkdialog - A small utility for fast and easy GUI building.
+ * Copyright (C) 2003-2007  László Pere <pipas@linux.pte.hu>
+ * Copyright (C) 2011-2012  Thunor <thunorsif@hotmail.com>
+ * Copyright (C) 2021-2022  step https://github.com/step-
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License along
+ * with this program; if not, write to the Free Software Foundation, Inc.,
+ * 51 Franklin Street, Fifth Floor, Boston, MA 02110-1301 USA.
+ */
+
+#ifndef WIDGET_CHOOSER_H
+#define WIDGET_CHOOSER_H
+
+/* Function prototypes */
+void widget_chooser_clear(variable *var);
+GtkWidget *widget_chooser_create(
+	AttributeSet *Attr, tag_attr *attr, gint Type);
+gchar *widget_chooser_envvar_all_construct(variable *var);
+gchar *widget_chooser_envvar_construct(GtkWidget *widget);
+void widget_chooser_fileselect(
+	variable *var, const char *name, const char *value);
+void widget_chooser_refresh(variable *var);
+void widget_chooser_removeselected(variable *var);
+void widget_chooser_save(variable *var);
+
+#endif

--- a/src/widgets.c
+++ b/src/widgets.c
@@ -38,6 +38,7 @@
 #include "stringman.h"
 #include "widget_button.h"
 #include "widget_checkbox.h"
+#include "widget_chooser.h"
 #include "widget_colorbutton.h"
 #include "widget_combobox.h"
 #include "widget_comboboxtext.h"
@@ -232,8 +233,8 @@ char *widget_get_text_value(GtkWidget *widget, int type)
 
 #if GTK_CHECK_VERSION(2,4,0)
 		case WIDGET_CHOOSER:
-			return gtk_file_chooser_get_filename(
-					GTK_FILE_CHOOSER(widget));
+			string = widget_chooser_envvar_construct(widget);
+			return string;
 			break;
 #endif
 
@@ -300,6 +301,9 @@ char *widgets_to_str(int itype)
 			break;
 		case WIDGET_CHECKBOX:
 			type = "CHECKBOX";
+			break;
+		case WIDGET_CHOOSER:
+			type = "CHOOSER";
 			break;
 		case WIDGET_COLORBUTTON:
 			type = "COLORBUTTON";


### PR DESCRIPTION
The file chooser widget has been included in gtkdialog since the early
days but was shadowed by the chooser dialog, which can be invoked with
the `fileselect` function.  Consequently, Thunor didn't give the chooser
widget the kind of feature uplift that was given to other widgets, and
moved the chooser widget to the miscellaneous example folder, where it
can still be found today.

However, for a specific class of applications - file viewer such as
mm_view and desktop wallpaper setters - the file chooser can be very
valuable: it is the only widget that allows embedding a full file
browser in a larger dialog.  The trouble was that the existing
implementation was not on par with the rest of gtkdialog.  This commit
fixes that and elevates the chooser widget to full citizenship. May
application developers find new ways to use it.

Now the chooser widget works consistently with the rest of gtkdialog:
- syntax[0]
- conditional actions
- standard signals
- widget signals[1]
- widget functions
- input and output directives[2]

[0] Custom attribute "when" is DEPRECATED but still recognized and
converted into attribute "signal" internally for backward compatibility.

[1] The confirm-overwrite signal isn't connected because the widget
only works in "file save" mode.

[2] "auto-refresh" and "file-monitor" custom tags not implemented.
Use a hidden text widget to assist if such matters are needed.

New demo scripts and HTML documentation included.

TODO: all reference pages and their index need to link to
new page chooser.html.

More to come for this PR: chooser file filters... stay tuned.
(But you can go ahead reviewing this first commit, which should
be self-standing).


