### PR TITLE
improve chooser widget

### DIFF
--- a/examples/chooser/chooser_event_counters
+++ b/examples/chooser/chooser_event_counters
@@ -1,31 +1,19 @@
 #!/bin/sh
 
-# step 2021: The following new custom tag attributes, which
-# are ignored by older builds, gracefully degrade for backward compatibility.
-# "default-file"      overrides <default> - specify both if sensible
-# "fs-filters-mime"   like <entry>'s and listed before fs-filters
-# "fs-filters"        like <entry>'s
-
-# step 2022: A warning about GTK2 vs GTK3 signal differences
+# step 2022: Quirks
 #
-# The GTK3 GtkFileChooser triggers the "selection-changed" and "update-preview"
-# signals differently than the GTK2 GtkFileChooser.  If you want your
-# application to work on both GTK2 and GTK3 use this script to study which
-# events trigger on GTK2 vs GTK3.  Test what happens on application start, on a
-# single change of selection, and on applying file filters (fs-filters and
-# fs-filters-mime).  For the first two cases, the difference between GTK2 and
-# GTK3 is small but for file filters it is huge.  Unlike GTK2, which does not
-# trigger events while the filter selector is updating the file list, GTK3
-# triggers a "selection-changed" and an "update-preview" for each new file that
-# enters the file list. Thus, using the GTK3 file filter in a directory that
-# contains thousands of files can result in your application having to process
-# thousands of actions and slowing down to a crawl while the file selector is
-# being applied.
+# On signal "current-folder-changed" the <variable> value matches the currently
+# selected folder only if the user has selected and entered that folder.  There
+# are no clear rules for deriving the value otherwise. (GTK2 and GTK3)
+#
+# When fs-filters or fs-filters-mime is defined, at times the <variable> value
+# that results from the user filtering the file list does not match the
+# selection. (GTK3)
 
 [ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
 
-[ -d "$1" ] && this="$1" ||
-	this="$(find "/usr/share/pixmaps" -maxdepth 1 -type f | shuf | head -1)"
+[ -d "$1" ] && image_folder="$1" || image_folder="/usr/share/pixmaps"
+this="$(find "$image_folder" -maxdepth 1 -type f | shuf | head -1)"
 
 chooser_attrs="
 default-file=\"$this\"
@@ -48,11 +36,11 @@ MAIN_DIALOG='
 			<action signal="file-activated">refresh:FILE_ACTIVATED</action>
 			<action signal="button-release-event">refresh:BUTTON_RELEASE_EVENT</action>
 
-			<action signal="button-release-event">echo "button-release-event $CHOOSER"</action>
-			<action signal="current-folder-changed">echo "current-folder-changed $CHOOSER"</action>
-			<action signal="file-activated">echo "file-activated $CHOOSER"</action>
-			<action signal="selection-changed">echo "selection-changed $CHOOSER"</action>
-			<action signal="update-preview">echo "update-preview $CHOOSER"</action>
+			<action signal="button-release-event">  echo "button-release-event   ($CHOOSER)"</action>
+			<action signal="current-folder-changed">echo "current-folder-changed ($CHOOSER)"</action>
+			<action signal="file-activated">        echo "file-activated         ($CHOOSER)"</action>
+			<action signal="selection-changed">     echo "selection-changed      ($CHOOSER)"</action>
+			<action signal="update-preview">        echo "update-preview         ($CHOOSER)"</action>
 		</chooser>
 		<frame Event counters>
 			<hbox homogeneous="true">

--- a/src/signals.c
+++ b/src/signals.c
@@ -2039,10 +2039,10 @@ void widget_file_monitor_try_create(variable *var, gchar *filename)
 #endif
 
 /***********************************************************************
- *                                                                     *
+ * Chooser                                                             *
  ***********************************************************************/
 
-void on_any_widget_file_activated_event(GtkWidget *widget, AttributeSet *Attr)
+void on_chooser_widget_file_activated_event(GtkWidget *widget, AttributeSet *Attr)
 {
 #ifdef DEBUG_TRANSITS
 	fprintf(stderr, "%s(): Entering.\n", __func__);
@@ -2055,11 +2055,22 @@ void on_any_widget_file_activated_event(GtkWidget *widget, AttributeSet *Attr)
 #endif
 }
 
+/* step 2022: Folder path != data value  (GTK2 and GTK3)
+ *
+ * Note that when the current-folder-changed event is sent its data value
+ * cannot be assumed to be the folder path; instead it can be either the file
+ * list selection - subject to the quirks that are discussed futher down for
+ * signal selection-changed - or a previously visited folder path when the
+ * navigation bar is used.  Applications should assume that the data value
+ * matches the actual folder path only when the user selects and activates
+ * (enters) a folder.
+ */
+
 /***********************************************************************
- *                                                                     *
+ * Chooser                                                             *
  ***********************************************************************/
 
-void on_any_widget_current_folder_changed_event(GtkWidget *widget, AttributeSet *Attr)
+void on_chooser_widget_current_folder_changed_event(GtkWidget *widget, AttributeSet *Attr)
 {
 #ifdef DEBUG_TRANSITS
 	fprintf(stderr, "%s(): Entering.\n", __func__);

--- a/src/signals.c
+++ b/src/signals.c
@@ -2087,42 +2087,58 @@ void on_chooser_widget_current_folder_changed_event(GtkWidget *widget, Attribute
  * Chooser                                                             *
  ***********************************************************************/
 
-/* step 2022: Work-around for GTK+-3 GtkFileChooser duplicate events issue.
+/* step 2022: Work-around implemented for GTK3 GtkFileChooser duplicate signals.
  *
- * The GTK3 file chooser widget triggers duplicate "selection-changed" and
- * "update-preview" events when fs-filters(-mime) is used to filter the file
- * list. See demo script "examples/chooser/chooser_event_counters".  Duplicates
- * do not occur with the GTK2 file chooser.  I have implemented a work-around
- * by defining a dedicated signal handling function for each of these two
- * signals.  The handler calls widget_signal_executor only if the current
- * widget data is non-empty and differs from the previous call, otherwise the
- * executor isn't called.  Thus, a repeated sequence of the same file path hits
- * execution only once, and never if the file path is empty.  This logic can
- * only work because the signal executor handles all actions defined for a
- * widget as a whole unit. It would not work with the older chooser
- * implementation, which handled each <action when> independently of other
- * actions.  Without this work-around, the demo script was showing literally
- * thousands of duplicate or empty events when changing fs-filters in
- * directory holding a large photo collection. The GTK2 file chooser benefits
- * from this work-around too, because it is known to trigger signals when the
- * file path is empty. */
+ * When the user filters the file list using the filter pull-down selector, at
+ * times the GTK3 file chooser sends bogus and/or duplicate "update-preview"
+ * and "selection-changed" signals.  `Bogus' means that the signal indicates a
+ * file path that wasn't selected. `Duplicate' means that the file path was
+ * already sent during the current filtering action. In a test case involving a
+ * folder with 4200 jpeg/png images inside, I observed nearly 1200 bad signals.
+ * The GTK2 file chooser isn't affected.  Two work-arounds are implemented to
+ * address bad signals.  In the first work-around the handler ignores a signal
+ * if the signal's event time equals the event time of the preceding signal.
+ * Since GTK3 assigns the same event time to most signals arising from the file
+ * list filter, effectively the first work-around eliminates nearly all bad
+ * signals.  A few bad signals still manage to go across the first barrier,
+ * e.g., an empty file path, a repetition of the same file path regardless of
+ * event time.  Work-around two blocks such signals. Work-arounds are only
+ * applied if the widget does have a file filter pull-down selector.
+ * In the test case I mentioned, the two work-arounds together reduced the
+ * number of signals that went across the barriers from 1200 down to 1.
+ * However, at times the file path carried by the passing signal didn't look
+ * selected in the file list.  There is no work-around for that. */
 
 void on_chooser_widget_selection_changed_event(GtkWidget *widget, AttributeSet *Attr)
 {
 	variable        *var   = NULL;
+	static guint32  prev_event_time = 0;
+	guint32         event_time;
 	static gchar    *prev  = NULL;
 	gchar           *value = NULL;
+	GSList          *fl;
 #ifdef DEBUG_TRANSITS
 	fprintf(stderr, "%s(): Entering.\n", __func__);
 #endif
 
-	value = widget_get_text_value(widget, WIDGET_CHOOSER);
-	if (value && *value) {
-		if (!prev || strcmp(prev, value) != 0)
-			widget_signal_executor(widget, Attr, "selection-changed"); /* it really did */
-		if (prev)
-			g_free(prev);
-		prev = value;
+	fl = gtk_file_chooser_list_filters(GTK_FILE_CHOOSER(widget));
+	if (fl == NULL)
+		widget_signal_executor(widget, Attr, "selection-changed");
+	else {
+		g_slist_free(fl);
+		event_time = gtk_get_current_event_time();
+		if (event_time == prev_event_time)
+			return;
+		prev_event_time = event_time;
+
+		value = widget_get_text_value(widget, WIDGET_CHOOSER);
+		if (value && *value) {
+			if (!prev || strcmp(prev, value) != 0)
+				widget_signal_executor(widget, Attr, "selection-changed");
+			if (prev)
+				g_free(prev);
+			prev = value;
+		}
 	}
 
 #ifdef DEBUG_TRANSITS
@@ -2137,21 +2153,34 @@ void on_chooser_widget_selection_changed_event(GtkWidget *widget, AttributeSet *
 void on_chooser_widget_update_preview_event(GtkWidget *widget, AttributeSet *Attr)
 {
 	variable        *var   = NULL;
+	static guint32  prev_event_time = 0;
+	guint32         event_time;
 	static gchar    *prev  = NULL;
 	gchar           *value = NULL;
+	GSList          *fl;
 #ifdef DEBUG_TRANSITS
 	fprintf(stderr, "%s(): Entering.\n", __func__);
 #endif
 
-	value = widget_get_text_value(widget, WIDGET_CHOOSER);
-	if (value && *value) {
-		if (!prev || strcmp(prev, value) != 0)
-			widget_signal_executor(widget, Attr, "update-preview"); /* it really did */
-		if (prev)
-			g_free(prev);
-		prev = value;
-	}
+	fl = gtk_file_chooser_list_filters(GTK_FILE_CHOOSER(widget));
+	if (fl == NULL)
+		widget_signal_executor(widget, Attr, "update-preview");
+	else {
+		g_slist_free(fl);
+		event_time = gtk_get_current_event_time();
+		if (event_time == prev_event_time)
+			return;
+		prev_event_time = event_time;
 
+		value = widget_get_text_value(widget, WIDGET_CHOOSER);
+		if (value && *value) {
+			if (!prev || strcmp(prev, value) != 0)
+				widget_signal_executor(widget, Attr, "update-preview");
+			if (prev)
+				g_free(prev);
+			prev = value;
+		}
+	}
 
 #ifdef DEBUG_TRANSITS
 	fprintf(stderr, "%s(): Exiting.\n", __func__);

--- a/src/signals.h
+++ b/src/signals.h
@@ -107,8 +107,8 @@ void widget_signal_executor(GtkWidget *widget, AttributeSet *Attr,
 	const gchar *signal_name);
 void widget_file_monitor_try_create(variable *var, gchar *filename);
 
-void on_any_widget_file_activated_event(GtkWidget *widget, AttributeSet *Attr);
-void on_any_widget_current_folder_changed_event(GtkWidget *widget, AttributeSet *Attr);
+void on_chooser_widget_file_activated_event(GtkWidget *widget, AttributeSet *Attr);
+void on_chooser_widget_current_folder_changed_event(GtkWidget *widget, AttributeSet *Attr);
 void on_chooser_widget_selection_changed_event(GtkWidget *widget, AttributeSet *Attr);
 void on_chooser_widget_update_preview_event(GtkWidget *widget, AttributeSet *Attr);
 #endif

--- a/src/widget_chooser.c
+++ b/src/widget_chooser.c
@@ -318,13 +318,13 @@ void widget_chooser_refresh(variable *var)
 		/* Connect signals */
 
 		g_signal_connect(G_OBJECT(var->Widget), "file-activated",
-			G_CALLBACK(on_any_widget_file_activated_event), (gpointer)var->Attributes);
+			G_CALLBACK(on_chooser_widget_file_activated_event), (gpointer)var->Attributes);
 		g_signal_connect(G_OBJECT(var->Widget), "selection-changed",
 			G_CALLBACK(on_chooser_widget_selection_changed_event), (gpointer)var->Attributes);
 		g_signal_connect(G_OBJECT(var->Widget), "update-preview",
 			G_CALLBACK(on_chooser_widget_update_preview_event), (gpointer)var->Attributes);
 		g_signal_connect(G_OBJECT(var->Widget), "current-folder-changed",
-			G_CALLBACK(on_any_widget_current_folder_changed_event), (gpointer)var->Attributes);
+			G_CALLBACK(on_chooser_widget_current_folder_changed_event), (gpointer)var->Attributes);
 		/* step: confirm-overwrite not implemented */
 	}
 

--- a/src/widget_chooser.c
+++ b/src/widget_chooser.c
@@ -376,7 +376,7 @@ void widget_chooser_save(variable *var)
 	/* We'll use the output file filename if available */
 	act = attributeset_get_first(&element, var->Attributes, ATTR_OUTPUT);
 	while (act) {
-		if (strncasecmp(act, "file:", 5) == 0 && strlen(act) > 5) {
+		if (strlen(act) > 5 && strncasecmp(act, "file:", 5)) {
 			filename = act + 5;
 			break;
 		}
@@ -427,7 +427,7 @@ static void widget_chooser_input_by_command(variable *var, char *command)
 	/* Opening pipe for reading... */
 	if (infile = widget_opencommand(command)) {
 		/* Read the file one line at a time */
-		while (fgets(line, 512, infile)) {
+		while (fgets(line, sizeof(line), infile)) {
 			g_string_append(text, line);
 		}
 
@@ -462,7 +462,7 @@ static void widget_chooser_input_by_file(variable *var, char *filename)
 
 	if (infile = fopen(filename, "r")) {
 		/* Read the file one line at a time */
-		while (fgets(line, 512, infile)) {
+		while (fgets(line, sizeof(line), infile)) {
 			g_string_append(text, line);
 		}
 


### PR DESCRIPTION
Now I'm satisfied with the way the chooser widget works in GTK3 and GTK2 for all practical purposes.  Two minor quirks remain:

* On signal `current-folder-changed` the `<variable>` value matches the currently selected folder only if the user has selected and entered that folder.  There are no clear rules for deriving the value otherwise. (GTK2 and GTK3)

* When `fs-filters` or `fs-filters-mime` are defined, at times the `<variable>` value that results from the user filtering the file list does not match the selection. (GTK3)