### PR TITLE
Allow shell input redirection `< /file` in action and input tags

### DIFF
--- a/src/gtkdialog_lexer.l
+++ b/src/gtkdialog_lexer.l
@@ -47,11 +47,13 @@ static gchar *process_string(gchar *str);
 
 extern int linenumber;
 gchar *Token;
+/* step: line number of last <action> or <input> tag */
+static int less_than_allowed_at = 0;
 
 %}
 
 	/**************************************************************
-	 * Thunor: Uncomment this to debug.
+	 * Thunor: Uncomment and unindent this to debug.
 	 **************************************************************
 	* %option debug */
 
@@ -586,7 +588,9 @@ gchar *Token;
 \<width\>        			{ Token="<width>"; return(WIDTH);   			}
 \<\/width\>      			{ Token="</width>"; return(EWIDTH);   			}
 
-\<input\>        			{ Token="<input>"; return(INPUT);   			}
+\<input\>        			{ Token="<input>";
+					  less_than_allowed_at = linenumber;
+					  return(INPUT);   					}
 \<\/input\>      			{ Token="</input>"; return(EINPUT);   			}
 \<\input\ file\> 			{ Token="<input file>"; return(INPUTFILE);   		}
 \<\input\ file[ ]+ 			{ Token="<input file>"; 
@@ -610,7 +614,9 @@ gchar *Token;
 	** The definition of action tags.
 	*/
 
-\<action\>     				{ Token="<action>"; return(ACTION);  			}
+\<action\>     				{ Token="<action>";
+					  less_than_allowed_at = linenumber;
+					  return(ACTION);					}
 \<action[ ]+   				{ Token="<action>";
 					  BEGIN(ST_TAG_ATTR);
 					  return(PART_ACTION); 					}
@@ -633,7 +639,7 @@ gchar *Token;
 					
 					/*
 					 * The quoted string. It can contain anything, except
-					 * unescaped double quote.
+					 * unescaped double quote. Multiple line OK.
 					 */
 \"	  				{
 					  Token = "double quote";
@@ -655,7 +661,7 @@ gchar *Token;
 												
 					/*
 					 * An unquoted string can contain anything except 
-					 * unescaped '<'.
+					 * unescaped '<'. Single line only.
 					 */
 [^ \n\t\>\<\"][^\n\<\\]*  		{
 					  Token = "string";
@@ -676,12 +682,26 @@ gchar *Token;
 					  yymore();
 												}
 
-<ST_STRING>"<"				{
+					/* step: special handling for shell '<' operator */
+<ST_STRING>"</"				{
 					  gtkdialog_lval.cval = g_strdup(yytext);
-					  gtkdialog_lval.cval[strlen(gtkdialog_lval.cval) - 1] = '\0';
-					  unput('<');
+					  gtkdialog_lval.cval[strlen(gtkdialog_lval.cval) - 2] = '\0';
+					  unput('/'); unput('<');
 					  BEGIN(0);
 					  return STRING;
+					  							}
+
+					/* step: special handling continued */
+<ST_STRING>"<"				{
+					  if (less_than_allowed_at == linenumber) {
+						yymore();
+					  } else {
+						gtkdialog_lval.cval = g_strdup(yytext);
+						gtkdialog_lval.cval[strlen(gtkdialog_lval.cval) - 1] = '\0';
+						unput('<');
+						BEGIN(0);
+						return STRING;
+					}
 					  							}
 
 												


### PR DESCRIPTION
This is to fix one of my pet peeves with gtkdialog, that is, inside `<action>` and `<input>` tags the shell input redirection operator `<` triggers a syntax error and aborts gtkdialog.

Traditionally this limitation is worked around with shell pipes or temporary files. Take for example an action that aims at printing the line count of `/etc/passwd` as a bare number without further text. This command would do `wc -l < /etc/passwd` but when gtkdialog sees the command, e.g. `<action>wc -l < /etc/passwd</action>`, it prints "gtkdialog: Error in line 1, near token 'string': syntax error" and exits. So we must rewrite the command as `<action>cat /etc/passwd | wc -l</action>`, which forks an additional process. Enter this commit. Now shell input redirection is valid syntax, and gtkdialog keeps going. Bash `<()` and `<<<` is also valid syntax now.

**Notes about this commit**

1. This syntax change is compatible with existing scripts simply because the new syntax could not be used before.
2. This syntax change is only enabled within the context of `<action>` and `<input>` tags. It would be trivial to enable it for all tags but why?
3. There must be at least one space between `<` and the `/` that follows because `</` was and remains reserved for closing tags.

**Test scriptlets**

```sh
MAIN_DIALOG='<button><action>wc -l < /etc/passwd</action></button>' gtkdialog -c &
MAIN_DIALOG='<button><action>bash -c "wc -l <(cat /etc/passwd)"</action></button>' gtkdialog -c &
MAIN_DIALOG='<button><action>bash -c "wc -l <<< 12345"</action></button>' gtkdialog -c &
MAIN_DIALOG='<button><action>exec 3< /etc/passwd && wc -l <&3</action></button>' gtkdialog -c &
MAIN_DIALOG='<button><action>bash -c "x=\$(< /etc/passwd) && echo \${#x} characters"</action></button>' gtkdialog -c &

MAIN_DIALOG='<text><input>wc -l < /etc/passwd</input></text>' gtkdialog -c &

MAIN_DIALOG='<button><action>wc -l </etc/passwd</action></button>' gtkdialog -c &

MAIN_DIALOG='<button><action condition="command_is_true(wc -l < /etc/passwd >&2; echo true)">echo yes</action></button>' gtkdialog -c &
```

**Notes about the gtkdialog lexer**

1. Line continuation with trailing backslash is not supported.
2. Multiline string is only supported if double-quoted.  Test with `<edit><default>`.
3. Multiline string does not work in shell actions, that is, it's OK in `<default>` tags but not OK in shell `<action>` tags.
3. Unquoted multiline string in `<action>` tag results in no action and no syntax error (subtle failure point).
4. Double-quoted strings can include `<`.  Quotes are passed to the underlying shell.