### PR TITLE
simplify file variables.c

### DIFF
--- a/src/automaton.c
+++ b/src/automaton.c
@@ -1231,10 +1231,11 @@ instruction_execute_push(
 	PIP_DEBUG("Widget created: %p", Widget);
 	
 	/*
-	 ** Now we create a new variable or refresh the old one for this
-	 ** new widget.
+	 ** Now we malloc a new named variable for this new widget.
+	 ** If the same variable name already exists for another widget that
+	 ** variable is reused for this new widget!
 	 */
-	variables_new_with_widget(Attr, tag_attributes, Widget, Widget_Type);
+	(void) variables_new_with_widget(Attr, tag_attributes, Widget, Widget_Type);
 
 	variables_set_attributes(attributeset_get_first(&element, Attr,
 		ATTR_VARIABLE), Attr);

--- a/src/signals.c
+++ b/src/signals.c
@@ -1623,8 +1623,8 @@ gboolean widget_signal_executor_eval_condition(gchar *condition)
 			 ***********************************************************/
 			if (condfunc == TYPE_CONDFUNC_ACTIVE) {
 
-				if (variables_is_avail_by_name(argument)) {
-					var = variables_get_by_name(argument);
+				var = variables_get_by_name(argument);
+				if (var != NULL) {
 
 					/* There's a class hierarchy to be aware of here */
 /* GtkWidget--->GtkContainer--->GtkBin--->GtkButton--->GtkToggleButton */
@@ -1732,8 +1732,8 @@ gboolean widget_signal_executor_eval_condition(gchar *condition)
 			 ***********************************************************/
 			} else if (condfunc == TYPE_CONDFUNC_SENSITIVE) {
 
-				if (variables_is_avail_by_name(argument)) {
-					var = variables_get_by_name(argument);
+				var = variables_get_by_name(argument);
+				if (var != NULL) {
 
 					state = gtk_widget_get_sensitive(var->Widget);
 
@@ -1753,8 +1753,8 @@ gboolean widget_signal_executor_eval_condition(gchar *condition)
 			 ***********************************************************/
 			} else if (condfunc == TYPE_CONDFUNC_VISIBLE) {
 
-				if (variables_is_avail_by_name(argument)) {
-					var = variables_get_by_name(argument);
+				var = variables_get_by_name(argument);
+				if (var != NULL) {
 
 					state = gtk_widget_get_visible(var->Widget);
 
@@ -1774,8 +1774,8 @@ gboolean widget_signal_executor_eval_condition(gchar *condition)
 			 ***********************************************************/
 			} else if (condfunc == TYPE_CONDFUNC_VARIABLE) {
 
-				if (variables_is_avail_by_name(argument)) {
-					var = variables_get_by_name(argument);
+				var = variables_get_by_name(argument);
+				if (var != NULL) {
 
 					strncpy(value,
 						widget_get_text_value(var->Widget, var->Type),

--- a/src/variables.c
+++ b/src/variables.c
@@ -69,7 +69,7 @@ variable *variables_new(const char *name);
 /* Redundant: Not being used: variable *variables_set_widget(const char *name, GtkWidget *widget); */
 /* Redundant: Not being used: variable *variables_set_parent(const char *name, GtkWidget *parent); */
 /* Redundant: Not being used: variable *variables_set_type(const char *name, int type); */
-gboolean variables_is_avail_by_name(const char *name);
+/* Redundant: Not being used: gboolean variables_is_avail_by_name(const char *name); */
 int _tree_insert(variable *new, variable *actual);
 static variable *_tree_find(const char *name, variable *actual);
 static gint do_variables_count_widgets(variable *actual, gint n);
@@ -100,7 +100,7 @@ void variables_print_one(variable *var)
 /***********************************************************************
  *                                                                     *
  ***********************************************************************/
-/* This function will create a new variable */
+/* This function will malloc a new named variable */
 
 variable *variables_new(const char *name)
 {
@@ -110,12 +110,9 @@ variable *variables_new(const char *name)
 	fprintf(stderr, "%s(): Entering.\n", __func__);
 #endif
 
-	/* 
-	 ** If the variable exists we simply returns without making a 
-	 ** a warning. 
-	 */
-	if (variables_is_avail_by_name(name))
-		return (variables_get_by_name(name));
+	/* step: assertion guard; for what I can see variables_new isn't called
+	 * for an already allocated name but adding this guard won't hurt. */
+	g_assert(variables_get_by_name(name) == NULL);
 
 	new = g_malloc(sizeof(variable));
 	strncpy(new->Name, name, NAMELEN);
@@ -205,10 +202,9 @@ variable *variables_new_with_widget(AttributeSet *Attr,
 	 ** If the variable exists we simply returns without making a 
 	 ** a warning.
 	 */
-	if (!variables_is_avail_by_name(name)) {
+	var = variables_get_by_name(name);
+	if (var == NULL) {
 		var = variables_new(name);
-	} else {
-		var = variables_get_by_name(name);
 	}
 
 	g_assert(var != NULL);
@@ -1016,13 +1012,13 @@ variable *variables_presentwindow(const char *name)
  *                                                                     *
  ***********************************************************************/
 
-gboolean variables_is_avail_by_name(const char *name)
-{
-	if (_tree_find(name, NULL) == NULL)
-		return (FALSE);
-	else
-		return (TRUE);
-}
+/* gboolean variables_is_avail_by_name(const char *name)       Redundant */
+/* { */
+/* 	if (_tree_find(name, NULL) == NULL) */
+/* 		return (FALSE); */
+/* 	else */
+/* 		return (TRUE); */
+/* } */
 
 /***********************************************************************
  *                                                                     *

--- a/src/variables.h
+++ b/src/variables.h
@@ -60,7 +60,7 @@ variable *variables_hide(const char *name);
 variable *variables_activate(const char *name);
 variable *variables_grabfocus(const char *name);
 variable *variables_presentwindow(const char *name);
-gboolean variables_is_avail_by_name(const char *name);
+/* gboolean variables_is_avail_by_name(const char *name);    Redundant */
 variable *variables_get_by_name(const char *name);
 gint variables_count_widgets(void);
 void variables_drop_by_window_id(variable *actual, gint window_id);


### PR DESCRIPTION
Function `variables_is_avail_by_name` is redundant so I decided to retire it because it obscures when malloc
did take place.  I didn't write new functions to replace it - I just reused existing functions consistently.
`variables_is_avail_by_name` is retired in favor of two simpler idioms:
```c
/* create */
var = variables_get_by_name(name); /* perform look-up */
if (var == NULL)
  var = variables_new(name); /* malloc */

/* use */
var = variables_get_by_name(name); /* perform look-up */
if (var != NULL) {
  /* use var */
}
```