### PR TITLE
lexer: add XML-style comments and fix line counter

### DIFF
--- a/examples/miscellaneous/comments.sh
+++ b/examples/miscellaneous/comments.sh
@@ -1,0 +1,50 @@
+#!/bin/sh
+
+[ -z $GTKDIALOG ] && GTKDIALOG=gtkdialog
+
+MAIN_DIALOG='
+<!--
+XML-style comments like this one work anywhere but:
+* inside double-quoted strings they become verbatim text;
+* inside a tag they are invalid;
+* comments cannot be nested.
+-->
+<window title="Comments" window-position="1" width-request="800" height-request="600">
+	<!-- a comment -->
+	<vbox scrollable="true"><!-- another comment -->
+		<text wrap="false" label="not a comment:
+<!-- #1 verbatim text inside double quotes -->">
+		</text>
+		<edit editable="false">
+			<height>40</height>
+			<default>"not a comment:
+<!-- #2 verbatim text inside double quotes -->"</default>
+		</edit>
+		<entry sensitive="false">
+			<!-- next line is chopped by a shell hack to avoid triggering a syntax error -->
+			'${HACK# <default>unquoted<!-- inside a tag is a -->syntax error</default>}'
+		</entry>
+		<!-- ok button -->
+		<hbox space-expand="true">
+			<button use-stock="true" label="gtk-ok"></button>
+			<!-- this comments out a whole button tag
+			<button use-stock="true" label="gtk-ok"></button>
+			-->
+		</hbox>
+		<hseparator></hseparator>
+		<text xalign="0.5" use-markup="true" label="<b>dump of MAIN_DIALOG</b>"></text>
+		<text wrap="false">
+			<input>echo "$MAIN_DIALOG" | cat -n</input>
+		</text>
+	</vbox>
+</window>
+'
+export MAIN_DIALOG
+
+case $1 in
+	-d | --dump) echo "$MAIN_DIALOG" ;;
+	*) $GTKDIALOG --program=MAIN_DIALOG ;;
+esac
+
+# vim:ft=xml:
+

--- a/src/gtkdialog_lexer.l
+++ b/src/gtkdialog_lexer.l
@@ -58,12 +58,25 @@ gchar *Token;
 %x EMBEDDED
 %x ST_TAG_ATTR ST_QUOTED_TAGATTR
 %x ST_STRING ST_QUOTED_STRING
+%x COMMENT
 
 %%
 
 	#ifdef DEBUG
 		g_message("%s(): Start", __func__);
 	#endif
+
+	/* step: XML-style comments  <!-- .... --> work anywhere but:
+	 * inside double-quoted strings they become verbatim text;
+	 * inside a tag they are invalid;
+	 * comments cannot be nested.
+	 */
+"<!--"           { BEGIN(COMMENT); }
+<COMMENT>"-->"   { BEGIN(0); }
+<COMMENT>\n      { ++linenumber; }
+<COMMENT>[^\n-]+ { ; }
+<COMMENT>.       { ; }
+
 
 ">"       				{ Token=">"; return(yytext[0]); 			}
 <*>$[ \t\n]* 				{ Token="indent chars"; 				}
@@ -101,7 +114,12 @@ gchar *Token;
 					  Token = "double quote";
 					  BEGIN(ST_QUOTED_TAGATTR);				}
 					  
-<ST_QUOTED_TAGATTR>[^\\"]+		{
+<ST_QUOTED_TAGATTR>\n			{
+					  Token = "string";
+					  ++linenumber;
+					  yymore();						}
+
+<ST_QUOTED_TAGATTR>[^\n\\"]+		{
 					  Token = "string";
 					  yymore();						}
 
@@ -332,7 +350,7 @@ gchar *Token;
 }
 
 \<edit[ ]+ { 
-	Token="<entry>"; 
+	Token="<edit>"; 
 	BEGIN(ST_TAG_ATTR);
 	return(PART_EDIT);
 }
@@ -639,7 +657,10 @@ gchar *Token;
 					  Token = "double quote";
 					  BEGIN(ST_QUOTED_STRING);				}
 					  
-<ST_QUOTED_STRING>[^\\"]+		{
+<ST_QUOTED_STRING>\n			{ ++linenumber;
+					  yymore();						}
+
+<ST_QUOTED_STRING>[^\n\\"]+		{
 					  yymore();						}
 
 <ST_QUOTED_STRING>"\\\""		{


### PR DESCRIPTION
This commit adds XML-style comments as a lexical feature that script
developers can use to easily document their code. It also fixes two
long-standing bugs: the line counter that references the location of
a syntax error did not count multi-line values; markup `<edit ` was
incorrectly reported as an `<entry>` token (with no ill consequences).

Prior to this commit the gtkdialog markup did not provide a native way
to enter comments. Several work-arounds were in use: side-loading
comments in a separate file; writing shell comments at the top/bottom/
middle of the shell script file; embedding shell comments in gtkdialog
markup using various ad-hoc (and fragile) lexical hacks; using a shell
function to create an envelope for comments; forking an `<action>` that
runs nothing but shell comments. These methods are still possible but
are discouraged for new scripts.

**BREAKING CHANGE**

Gtkdialog versions <= 0.8.4 can't parse XML-style comments and error out
so this feature is not backward-compatible.
See the new script `examples/miscellaneous/comments.sh` for ways you
can use - and not use - comments in your new scripts.