### PR TITLE
new window attr: 'icon-name'

### DIFF
--- a/doc/reference/window.html
+++ b/doc/reference/window.html
@@ -116,6 +116,12 @@
 <td class="wiki">0.8.1</td>
 </tr>
 <tr>
+<td class="wiki">icon-name</td>
+<td class="wiki">Gtk theme icon</td>
+<td class="wiki"></td>
+<td class="wiki">0.8.5</td>
+</tr>
+<tr>
 <td class="wiki">block-function-signals</td>
 <td class="wiki">Block signal emissions from functions</td>
 <td class="wiki"><tt>true</tt> or <tt>false</tt></td>

--- a/src/widget_window.c
+++ b/src/widget_window.c
@@ -176,6 +176,13 @@ GtkWidget *widget_window_create(
 layer_set:
 #endif
 
+	/* app id and theme window/taskbar icon */
+	value = get_tag_attribute(attr, "icon-name");
+	if (value) {
+		gtk_window_set_icon_name(GTK_WINDOW(widget), value);
+		g_set_prgname(value);
+	}
+
 	/* Set a default window title */
 	attributeset_set_if_unset(Attr, ATTR_LABEL, PACKAGE);
 	gtk_window_set_title(GTK_WINDOW(widget), 


### PR DESCRIPTION
This allows the use of a gtk theme icon for the window/taskbar icon.
It works in gtk2 and gtk3. It is useful if you add a theme icon
(can and should be in the 'hicolor' theme) for your app.
This is needed for wayland support (eg sfwbar can now display
appropriate icons instead of the default) however the old
method of 'image-name' doesn't work in wayland because 'app_id'
is needed. This is why there is a call to `g_set_prgname()`