### PR TITLE
meson: fix installation of gtkdialog.png icon

### DIFF
--- a/data/meson.build
+++ b/data/meson.build
@@ -1,0 +1,4 @@
+install_data(
+  join_paths('icons', 'hicolor', '32x32', 'apps', 'gtkdialog.png'),
+  install_dir : join_paths(get_option('datadir'), 'icons', 'hicolor', '32x32', 'apps'),
+  )

--- a/meson.build
+++ b/meson.build
@@ -18,3 +18,4 @@ else
 endif
 
 subdir('src')
+subdir('data')


### PR DESCRIPTION
Simply, the icon wasn't installed with meson  and the window manager / taskbar
was showing whatever it's fallback icon was.