### PR TITLE
Update documentation for 0.8.5

### DIFF
--- a/doc/reference/button.html
+++ b/doc/reference/button.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>button widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkButton.html">GtkButton</a> containing either a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a>, a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImage.html">GtkImage</a> or both packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHBox.html">GtkHBox</a> or <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVBox.html">GtkVBox</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkButton.html">GtkButton</a> containing either a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a>, a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkImage.html">GtkImage</a> or both packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkHBox.html">GtkHBox</a> or <a href="https://developer-old.gnome.org/gtk2/2.24/GtkVBox.html">GtkVBox</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Button.html">GtkButton</a> containing either a <a href="https://docs.gtk.org/gtk3/class.Label.html">GtkLabel</a>, a <a href="https://docs.gtk.org/gtk3/class.Image.html">GtkImage</a> or both packed inside a <a href="https://docs.gtk.org/gtk3/class.Box.html">GtkBox</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;button yes no ok cancel help tag_attr=&quot;value&quot;...&gt;
@@ -102,7 +102,7 @@
 &lt;/button&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkButton.html#GtkButton.object-hierarchy">GtkButton</a> widget and ancestor class properties.</p>
+<p>See the GtkButton widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -163,7 +163,7 @@
 <tr>
 <td class="wiki">stock-icon-size</td>
 <td class="wiki">The size of the GTK stock icon</td>
-<td class="wiki">GtkIconSize</a>)</td>
+<td class="wiki"><tt>0</tt> to <tt>6</tt> (see <a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Themeable-Stock-Images.html#GtkIconSize">GtkIconSize</a> - Gtk2)</td>
 <td class="wiki">0.8.1</td>
 </tr>
 </tbody>
@@ -223,7 +223,7 @@
 <tr>
 <td class="wiki">input file stock=“<em>gtk-image</em>”<sup>[4]</sup></td>
 <td class="wiki">GTK stock icon ID</td>
-<td class="wiki">full list</a>)</td>
+<td class="wiki"><tt>gtk-about</tt>, <tt>gtk-add</tt> ... (<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Stock-Items.html#GTK-STOCK-ABOUT:CAPS">full list</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -295,10 +295,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkButton.html#GtkButton-clicked">clicked</a>”, emitted when the button has been activated (pressed and released).</p>
+<p>The default signal is “clicked” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkButton.html#GtkButton-clicked">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/method.Button.clicked.html">Gtk3</a>), emitted when the button has been activated (pressed and released).</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -394,7 +395,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -487,8 +488,8 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li><p>The existing “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkButton.html#GtkButton--image-position">image-position</a>” GTK+ property – normally only applicable to stock buttons – has been extended to apply to all Gtkdialog buttons.</p></li>
-<li><p>The existing “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkBox.html#GtkBox--homogeneous">homogeneous</a>” GTK+ property – applicable to the hbox and vbox – can be used here to effect the box inside the button when including an image and a label.</p></li>
+<li><p>The existing “image-position” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkButton.html#GtkButton--image-position">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Button.image-position.html">Gtk3</a>) GTK+ property – normally only applicable to stock buttons – has been extended to apply to all Gtkdialog buttons.</p></li>
+<li><p>The existing “homogeneous” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkBox.html#GtkBox--homogeneous">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Box.homogeneous.html">Gtk3</a>) GTK+ property – applicable to the hbox and vbox – can be used here to affect the box inside the button when including an image and a label.</p></li>
 <li><p>Theme icons default to 20 and do not scale or refresh (the “theme-icon-size” custom tag attribute can be used to request a size).</p></li>
 <li><p>Stock icons default to GTK_ICON_SIZE_BUTTON and do not scale or refresh (the “stock-icon-size” custom tag attribute can be used to request a size).</p></li>
 </ol>
@@ -535,16 +536,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/checkbox.html
+++ b/doc/reference/checkbox.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>checkbox widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCheckButton.html">GtkCheckButton</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkCheckButton.html">GtkCheckButton</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.CheckButton.html">GtkCheckButton</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;checkbox tag_attr=&quot;value&quot;...&gt;
@@ -101,7 +101,7 @@
 &lt;/checkbox&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCheckButton.html#GtkCheckButton.object-hierarchy">GtkCheckButton</a> widget and ancestor class properties.</p>
+<p>See the GtkCheckButton widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -264,10 +264,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html#GtkToggleButton-toggled">toggled</a>”, emitted when the state is changed.</p>
+<p>The default signal is “toggled” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html#GtkToggleButton-toggled">Gtk2</a>”,<a href="https://docs.gtk.org/gtk3/signal.ToggleButton.toggled.html">Gtk3</a>) emitted when the state is changed.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -375,7 +376,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -513,16 +514,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/chooser.html
+++ b/doc/reference/chooser.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,8 +83,10 @@
 					<tr>
 						<td>
 <h1>chooser widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooserWidget.html">GtkFileChooserWidget</a>
-that uses <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html">GtkFileChooser</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkFileChooserWidget.html">GtkFileChooserWidget</a>
+that uses <a href="https://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html">GtkFileChooser</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.FileChooserWidget.html">GtkFileChooserWidget</a>
+that uses <a href="https://docs.gtk.org/gtk3/iface.FileChooser.html">GtkFileChooser</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;chooser tag_attr=&quot;value&quot;...&gt;
@@ -101,7 +102,7 @@ that uses <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html"
 &lt;/chooser&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooserWidget.html#GtkFileChooserWidget.object-hierarchy">GtkFileChooserWidget</a> widget and ancestor class properties.</p>
+<p>See the GtkFileChooserWidget widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -132,7 +133,7 @@ that uses <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html"
 <tr>
 <td class="wiki">fs-filters-mime<sup>[2]</sup></td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
+<td class="wiki">... (<a href="https://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki">0.8.5</td>
 </tr>
 </tbody>
@@ -228,26 +229,14 @@ that uses <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html"
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is "<a href="https://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html#GtkFileChooser-file-activated">file-activated</a> emitted when the user "activates" a file in the file chooser. This can happen by double-clicking on a file in the file list, or by pressing Enter.</p>
+<p>The default signal is "file-activated" (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html#GtkFileChooser-file-activated">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.FileChooser.file-activated.html">Gtk3</a>) emitted when the user "activates" a file in the file chooser. This can happen by double-clicking on a file in the file list, or by pressing Enter.</p>
 <p>The "selection-changed" signal is emitted when there is a change in the set of selected files in the file list.</p>
 <p>The "update-preview" signal is emitted when the preview in a file chooser should be regenerated. For example, this can happen when the currently selected file changes. This signal is still emitted even though the current implementation does not display a preview of the selected file.</p>
 <p>The "current-folder-changed" signal is emitted when the current folder in a chooser widget changes.</p>
 <p>The "confirm-overwrite" signal is emitted whenever it would be appropriate to present a confirmation dialog when the user has selected a file name that already exists. The current implementation never emits this signal.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>,
-<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -355,7 +344,7 @@ that uses <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html"
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -496,16 +485,14 @@ that uses <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFileChooser.html"
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2022-01-15 <a href="https:github.com/step-">step</a></td>
-									<td class="footer" width="33%" align="center"><a href="https://puppylinux-woof-CE/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/colorbutton.html
+++ b/doc/reference/colorbutton.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>colorbutton widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html">GtkColorButton</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html">GtkColorButton</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.ColorButton.html">GtkColorButton</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;colorbutton tag_attr=&quot;value&quot;...&gt;
@@ -100,7 +100,7 @@
 &lt;/colorbutton&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html#GtkColorButton.object-hierarchy">GtkColorButton</a> widget and ancestor class properties.</p>
+<p>See the GtkColorButton widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -257,10 +257,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html#GtkColorButton-color-set">color-set</a>”, emitted when the user selects a colour.</p>
+<p>The default signal is “color-set” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html#GtkColorButton-color-set">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.ColorButton.color-set.html">Gtk3</a>), emitted when the user selects a colour.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -362,7 +363,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -455,7 +456,7 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li>Setting the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html#GtkColorButton--use-alpha">use-alpha</a>” tag attribute to true will enable alpha selection. Alpha can be passed in following the <em>#rrggbb</em> value separated by a ‘<tt>|</tt>’ character, or via the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html#GtkColorButton--alpha">alpha</a>” tag attribute. Although the colour selection dialog displays alpha as an 8bit 0-255 value, GTK+ and Gtkdialog manage it as a 16bit 0-65535 value and therefore it’ll require converting between the two formats. To convert from 8bit to 16bit use <tt>alpha * 257</tt> and from 16bit to 8bit use <tt>(alpha + 257 / 2) / 257</tt>.</li>
+<li>Setting the “use-alpha” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html#GtkColorButton--use-alpha">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.ColorButton.use-alpha.html">Gtk3</a>) tag attribute to true will enable alpha selection. Alpha can be passed in following the <em>#rrggbb</em> value separated by a ‘<tt>|</tt>’ character, or via the “alpha” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkColorButton.html#GtkColorButton--alpha">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.ColorButton.alpha.html">Gtk3</a>) tag attribute. Although the colour selection dialog displays alpha as an 8bit 0-255 value, GTK+ and Gtkdialog manage it as a 16bit 0-65535 value and therefore it’ll require converting between the two formats. To convert from 8bit to 16bit use <tt>alpha * 257</tt> and from 16bit to 8bit use <tt>(alpha + 257 / 2) / 257</tt>.</li>
 </ol>
 <p>This widget was introduced in version 0.7.21.</p>
 <hr>
@@ -501,16 +502,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/combobox.html
+++ b/doc/reference/combobox.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,7 @@
 					<tr>
 						<td>
 <h1>combobox widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCombo.html">GtkCombo</a></p>
+<p>A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkCombo.html">GtkCombo</a></p>
 <p>This widget has been deprecated since GTK+ 2.4 and <a href="comboboxtext.html">comboboxtext</a> or <a href="comboboxentry.html">comboboxentry</a> are recommended as replacements. <strong>It has been removed from GTK+ 3.0</strong></p>
 <hr>
 <h2>Definition</h2>
@@ -96,7 +95,7 @@
 &lt;/combobox&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCombo.html#GtkCombo.object-hierarchy">GtkCombo</a> widget and ancestor class properties.</p>
+<p>See the <a href="https://developer-old.gnome.org/gtk2/2.24/GtkCombo.html#GtkCombo.object-hierarchy">GtkCombo</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -189,7 +188,7 @@
 <h2 id="signals">Signals</h2>
 <p>There is no default signal for this widget.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -279,7 +278,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -416,16 +415,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/comboboxentry.html
+++ b/doc/reference/comboboxentry.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>comboboxentry widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkComboBoxEntry.html">GtkComboBoxEntry</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkComboBoxEntry.html">GtkComboBoxEntry</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk4/ctor.ComboBox.new_with_entry.html">GtkComboBox>new_with_entry</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;comboboxentry tag_attr=&quot;value&quot;...&gt;
@@ -101,7 +101,7 @@
 &lt;/comboboxentry&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkComboBoxEntry.html#GtkComboBoxEntry.object-hierarchy">GtkComboBoxEntry</a> widget and ancestor class properties.</p>
+<p>See the GtkComboBoxEntry widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -156,7 +156,7 @@
 <tr>
 <td class="wiki">fs-filters-mime</td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
+<td class="wiki">... (<a href="https://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -294,11 +294,12 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkComboBox.html#GtkComboBox-changed">changed</a>”, emitted when the active item is changed and when typing into the entry.</p>
-<p>The “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-activate">activate</a>” signal is emitted when the user activates the entry with the Enter key.</p>
+<p>The default signal is “changed” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkComboBox.html#GtkComboBox-changed">Gtk2</a>, <a href="https://docs.gtk.org/gtk4/signal.ComboBox.changed.html">Gtk3</a>), emitted when the active item is changed and when typing into the entry.</p>
+<p>The “activate” signal is emitted when the user activates the entry with the Enter key.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -412,7 +413,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -551,16 +552,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/comboboxtext.html
+++ b/doc/reference/comboboxtext.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>comboboxtext widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkComboBox.html">GtkComboBox</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkComboBox.html">GtkComboBox</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.ComboBoxText.html">GtkComboBoxText</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;comboboxtext tag_attr=&quot;value&quot;...&gt;
@@ -101,7 +101,7 @@
 &lt;/comboboxtext&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkComboBox.html#GtkComboBox.object-hierarchy">GtkComboBox</a> widget and ancestor class properties.</p>
+<p>See the GtkComboBox widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -156,7 +156,7 @@
 <tr>
 <td class="wiki">fs-filters-mime</td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
+<td class="wiki">... (<a href="https://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -294,10 +294,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkComboBox.html#GtkComboBox-changed">changed</a>”, emitted when the active item is changed.</p>
+<p>The default signal is  “changed” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkComboBox.html#GtkComboBox-changed">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.ComboBox.changed.html">Gtk3</a>), emitted when the active item is changed.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -411,7 +412,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -547,16 +548,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/edit.html
+++ b/doc/reference/edit.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>edit widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkTextView.html">GtkTextView</a> packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkTextView.html">GtkTextView</a> packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.TextView.html">GtkTextView</a> packed inside a <a href="https://docs.gtk.org/gtk3/class.ScrolledWindow.html">GtkScrolledWindow</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;edit tag_attr=&quot;value&quot;...&gt;
@@ -99,7 +99,7 @@
 &lt;/edit&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkTextView.html#GtkTextView.object-hierarchy">GtkTextView</a> widget and ancestor class properties.</p>
+<p>See the GtkTextView widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -247,7 +247,8 @@
 <p>There is no default signal for this widget.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -355,7 +356,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -493,16 +494,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/entry.html
+++ b/doc/reference/entry.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>entry widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html">GtkEntry</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkEntry.html">GtkEntry</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Entry.html">GtkEntry</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;entry tag_attr=&quot;value&quot;...&gt;
@@ -102,7 +102,7 @@
 &lt;/entry&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry.object-hierarchy">GtkEntry</a> widget and ancestor class properties.</p>
+<p>See the GtkEntry widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -157,7 +157,7 @@
 <tr>
 <td class="wiki">fs-filters-mime</td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
+<td class="wiki">... (<a href="https://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki">0.7.21</td>
 </tr>
 <tr>
@@ -302,11 +302,12 @@
 </table>
 <h2 id="signals">Signals</h2>
 <p>The default signal is “changed”, emitted when typing into the entry.</p>
-<p>The “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-activate">activate</a>” signal is emitted when the user activates the entry with the Enter key (since 0.7.21).</p>
-<p>For GTK+ 2.16 and later, the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-icon-press">icon-press</a>” and “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-icon-release">icon-release</a>” signals are emitted when an activatable icon is pressed or released, but these signal names will be prefixed with either “primary-” or “secondary-” to indicate the source icon (since 0.7.21).</p>
+<p>The “activate” (<a href="https://docs.gtk.org/gtk3/signal.Entry.activate.html">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/vfunc.Entry.activate.html">Gtk3</a>) signal is emitted when the user activates the entry with the Enter key (since 0.7.21).</p>
+<p>For GTK+ 2.16 and later, the “icon-press” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-icon-press">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.Entry.icon-press.html">Gtk3</a>) and “icon-release” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-icon-release">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.Entry.icon-release.html">Gtk3</a>) signals are emitted when an activatable icon is pressed or released, but these signal names will be prefixed with either “primary-” or “secondary-” to indicate the source icon (since 0.7.21).</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -426,7 +427,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -562,16 +563,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>
@@ -580,7 +579,6 @@
 			</td>
 		</tr>
 	</table>
-
 </body>
 </html>
 

--- a/doc/reference/eventbox.html
+++ b/doc/reference/eventbox.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>eventbox widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkEventBox.html">GtkEventBox</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkEventBox.html">GtkEventBox</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.EventBox.html">GtkEventBox</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;eventbox tag_attr=&quot;value&quot;...&gt;
@@ -95,7 +95,7 @@
 &lt;/eventbox&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkEventBox.html#GtkEventBox.object-hierarchy">GtkEventBox</a> widget and ancestor class properties.</p>
+<p>See the GtkEventBox widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -182,7 +182,8 @@
 <h2 id="signals">Signals</h2>
 <p>There is no default signal for this widget.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -260,7 +261,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki"></td>
 </tr>
@@ -397,16 +398,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/expander.html
+++ b/doc/reference/expander.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>expander widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkExpander.html">GtkExpander</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkExpander.html">GtkExpander</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Expander.html">GtkExpander</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;expander tag_attr=&quot;value&quot;...&gt;
@@ -101,7 +101,7 @@
 &lt;/expander&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkExpander.html#GtkExpander.object-hierarchy">GtkExpander</a> widget and ancestor class properties.</p>
+<p>See the GtkExpander widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -258,10 +258,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkExpander.html#GtkExpander-activate">activate</a>”, emitted when the expander is activated.</p>
+<p>The default signal is “activate” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkExpander.html#GtkExpander-activate">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.Expander.activate.html">Gtk3</a>), emitted when the expander is activated.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -363,7 +364,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki"></td>
 </tr>
@@ -503,16 +504,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/export
+++ b/doc/reference/export
@@ -39,7 +39,7 @@ clrPRE="#e8e8f0"
 # alternative browsers and then the CSS beautifies and tweaks it.
 echo '
 <!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+	"https://www.w3.org/TR/html4/loose.dtd">
 
 <html>
 <head>
@@ -169,8 +169,8 @@ echo '</p>
 							<table width="100%" cellpadding="0px" cellspacing="0px">
 								<tr>
 									<td class="footer" width="33%" align="center">'$(date "+%Y-%m-%d")' <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="33%" align="center"><a href="https://code.google.com/p/gtkdialog/">Project Page</a></td>
+									<td class="footer" width="33%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/fontbutton.html
+++ b/doc/reference/fontbutton.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>fontbutton widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFontButton.html">GtkFontButton</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkFontButton.html">GtkFontButton</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.FontButton.html">GtkFontButton</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;fontbutton tag_attr=&quot;value&quot;...&gt;
@@ -100,7 +100,7 @@
 &lt;/fontbutton&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFontButton.html#GtkFontButton.object-hierarchy">GtkFontButton</a> widget and ancestor class properties.</p>
+<p>See the GtkFontButton widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -257,10 +257,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkFontButton.html#GtkFontButton-font-set">font-set</a>”, emitted when the user selects a font.</p>
+<p>The default signal is “font-set” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkFontButton.html#GtkFontButton-font-set">Gtk2</a> ,<a href="https://docs.gtk.org/gtk3/signal.FontButton.font-set.html">Gtk3</a>), emitted when the user selects a font.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -362,7 +363,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki"></td>
 </tr>
@@ -498,16 +499,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/frame.html
+++ b/doc/reference/frame.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>frame widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkFrame.html">GtkFrame</a> containing a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVBox.html">GtkVBox</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkFrame.html">GtkFrame</a> containing a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkVBox.html">GtkVBox</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Frame.html">GtkFrame</a> containing a <a href="https://docs.gtk.org/gtk3/class.VBox.html">GtkVBox</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;frame label&gt;
@@ -183,7 +183,8 @@
 <h2 id="signals">Signals</h2>
 <p>There is no default signal for this widget.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -279,7 +280,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -415,16 +416,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/hbox.html
+++ b/doc/reference/hbox.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>hbox widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHBox.html">GtkHBox</a> optionally packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkViewport.html">GtkViewport</a> inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkHBox.html">GtkHBox</a> optionally packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkViewport.html">GtkViewport</a> inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>gtk3: A <a href="https://docs.gtk.org/gtk3/class.HBox.html">GtkHBox</a> optionally packed inside a <a href="https://docs.gtk.org/gtk3/class.Viewport.html">GtkViewport</a> inside a <a href="https://docs.gtk.org/gtk3/class.ScrolledWindow.html">GtkScrolledWindow</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;hbox tag_attr=&quot;value&quot;...&gt;
@@ -97,7 +97,7 @@
 &lt;/hbox&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHBox.html#GtkHBox.object-hierarchy">GtkHBox</a> widget and ancestor class properties.</p>
+<p>See the GtkHBox widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -158,7 +158,7 @@
 <tr>
 <td class="wiki">shadow-type</td>
 <td class="wiki">Viewport shadow type</td>
-<td class="wiki">GtkShadowType</a>)</td>
+<td class="wiki"><tt>0</tt> to <tt>4</tt> (see GtkShadowType <a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Standard-Enumerations.html#GtkShadowType">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/enum.ShadowType.html">Gtk3</a>)</td>
 <td class="wiki">0.8.1</td>
 </tr>
 </tbody>
@@ -232,7 +232,8 @@
 <h2 id="signals">Signals</h2>
 <p>There is no default signal for this widget.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -310,7 +311,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -406,7 +407,7 @@
 <li><p>By default the frame widget and every widget automatically placed inside a scrolled window (edit, tree, list, table and optionally the h/vbox) are packed with expand and fill set to true, otherwise widgets are packed with expand and fill set to false. This rather quirky system constitutes the original Gtkdialog widget packing method and therefore must continue to be supported, but since 0.7.21 it’s now possible to override this behaviour globally with the –space-expand=state and –space-fill=state command line options, at the h/vbox container level or at the individual widget level or a combination thereof.</p></li>
 <li><p>The scrolled window has a default dimension of 200x100 which can be overridden with the height and/or width directives.</p></li>
 </ol>
-<p>This widget has a default spacing of 5 which can be overridden with the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkBox.html#GtkBox--spacing">spacing</a>” tag attribute.</p>
+<p>This widget has a default spacing of 5 which can be overridden with the “spacing” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkBox.html#GtkBox--spacing">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Box.spacing.html">Gtk3</a>) tag attribute.</p>
 <hr>
 <p>
 <a href="button.html">button</a>, 
@@ -450,16 +451,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/hscale.html
+++ b/doc/reference/hscale.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>hscale widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHScale.html">GtkHScale</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkHScale.html">GtkHScale</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.HScale.html">GtkHScale</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;hscale tag_attr=&quot;value&quot;...&gt;
@@ -101,7 +101,7 @@
 &lt;/hscale&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHScale.html#GtkHScale.object-hierarchy">GtkHScale</a> widget and ancestor class properties.</p>
+<p>See the GtkHScale widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -275,8 +275,8 @@
 </tr>
 <tr>
 <td class="wiki">item</td>
-<td class="wiki">Input data for marks and markup<sup>[1]</sup></td>
-<td class="wiki">markup</a></em> (optional)</td>
+<td class="wiki">Input data for marks and markup<sup><a href="#note1">[1]</a></sup></td>
+<td class="wiki">value: <em>position</em><sup>(<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Standard-Enumerations.html#GtkPositionType">gtk2</a>)</sup><sup>(<a href="https://docs.gtk.org/gtk3/enum.PositionType.html">gtk3</a>)</sup> <tt>|</tt> <em>markup</em><sup>(<a href="https://developer-old.gnome.org/pango/stable/PangoMarkupFormat.html">gtk2</a>)</sup><sup>(<a href="https://docs.gtk.org/Pango/pango_markup.html">gtk3</a>)</sup> (optional)</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -288,10 +288,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkRange.html#GtkRange-value-changed">value-changed</a>”, emitted when the range value changes.</p>
+<p>The default signal is “value-changed" (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkRange.html#GtkRange-value-changed">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.Range.value-changed.html">Gtk3</a>), emitted when the range value changes.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -387,7 +388,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -480,7 +481,7 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li>Scale marks and markup require at least <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScale.html#gtk-scale-add-mark">GTK+ 2.16</a>.</li>
+<li>Scale marks and markup require at least <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScale.html#gtk-scale-add-mark">GTK+ 2.16</a>.</li>
 </ol>
 <p>This widget was introduced in version 0.7.21.</p>
 <hr>
@@ -526,16 +527,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/hseparator.html
+++ b/doc/reference/hseparator.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,14 +83,14 @@
 					<tr>
 						<td>
 <h1>hseparator widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHSeparator.html">GtkHSeparator</a></p>
+<p>A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkHSeparator.html">GtkHSeparator</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;hseparator tag_attr=&quot;value&quot;...&gt;
 &lt;/hseparator&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHSeparator.html#GtkHSeparator.object-hierarchy">GtkHSeparator</a> widget and ancestor class properties.</p>
+<p>See the <a href="https://developer-old.gnome.org/gtk2/2.24/GtkHSeparator.html#GtkHSeparator.object-hierarchy">GtkHSeparator</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -162,16 +161,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/list.html
+++ b/doc/reference/list.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,7 @@
 					<tr>
 						<td>
 <h1>list widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkList.html">GtkList</a> packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkViewport.html">GtkViewport</a> inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkList.html">GtkList</a> packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkViewport.html">GtkViewport</a> inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
 <p>This widget has been deprecated since GTK+ 2.0 and <a href="tree.html">tree</a> is recommended as a replacement. <strong>It has been removed from GTK+ 3.0</strong></p>
 <hr>
 <h2>Definition</h2>
@@ -103,7 +102,7 @@
 &lt;/list&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkList.html#GtkList.object-hierarchy">GtkList</a> widget and ancestor class properties.</p>
+<p>See the <a href="https://developer-old.gnome.org/gtk2/2.24/GtkList.html#GtkList.object-hierarchy">GtkList</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -158,7 +157,7 @@
 <tr>
 <td class="wiki">shadow-type</td>
 <td class="wiki">Viewport shadow type</td>
-<td class="wiki">GtkShadowType</a>)</td>
+<td class="wiki"><tt>0</tt> to <tt>4</tt> (see <a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Standard-Enumerations.html#GtkShadowType">GtkShadowType</a>)</td>
 <td class="wiki">0.8.1</td>
 </tr>
 <tr>
@@ -290,10 +289,10 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkList.html#GtkList-selection-changed">selection-changed</a>”, emitted when the selection has just changed.</p>
+<p>The default signal is “<a href="https://developer-old.gnome.org/gtk2/2.24/GtkList.html#GtkList-selection-changed">selection-changed</a>”, emitted when the selection has just changed.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -395,7 +394,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -535,16 +534,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/menu.html
+++ b/doc/reference/menu.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>menu widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html">GtkMenuItem</a> or <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImageMenuItem.html">GtkImageMenuItem</a> with a submenu.</p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html">GtkMenuItem</a> or <a href="https://developer-old.gnome.org/gtk2/2.24/GtkImageMenuItem.html">GtkImageMenuItem</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.MenuItem.html">GtkMenuItem</a> or <a href="https://docs.gtk.org/gtk3/class.ImageMenuItem.html">GtkImageMenuItem</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;menu tag_attr=&quot;value&quot;...&gt;
@@ -102,7 +102,7 @@
 &lt;/menu&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html#GtkMenuItem.object-hierarchy">GtkMenuItem</a> or <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImageMenuItem.html#GtkImageMenuItem.object-hierarchy">GtkImageMenuItem</a> widget and ancestor class properties.</p>
+<p>See the GtkMenuItem or GtkImageMenuItem widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -139,7 +139,7 @@
 <tr>
 <td class="wiki">stock-id</td>
 <td class="wiki">GTK stock icon ID</td>
-<td class="wiki">full list</a>)</td>
+<td class="wiki"><tt>gtk-about</tt>, <tt>gtk-add</tt> ... (<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Stock-Items.html#GTK-STOCK-ABOUT:CAPS">full list</a>)</td>
 <td class="wiki">0.7.21</td>
 </tr>
 <tr>
@@ -265,10 +265,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html#GtkMenuItem-activate">activate</a>”, emitted when the item is activated.</p>
+<p>The default signal is “activate” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html#GtkMenuItem-activate">Gtk2</a> ,<a href="https://docs.gtk.org/gtk3/signal.MenuItem.activate.html">Gtk3</a>), emitted when the item is activated.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -358,7 +359,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -497,16 +498,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/menubar.html
+++ b/doc/reference/menubar.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>menubar widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuBar.html">GtkMenuBar</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkMenuBar.html">GtkMenuBar</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.MenuBar.html">GtkMenuBar</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;menubar tag_attr=&quot;value&quot;...&gt;
@@ -95,7 +95,7 @@
 &lt;/menubar&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuBar.html#GtkMenuBar.object-hierarchy">GtkMenuBar</a> widget and ancestor class properties.</p>
+<p>See the GtkMenuBar widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -182,7 +182,8 @@
 <h2 id="signals">Signals</h2>
 <p>There is no default signal for this widget.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -260,7 +261,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -396,16 +397,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/menuitem.html
+++ b/doc/reference/menuitem.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>menuitem widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html">GtkMenuItem</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/gtk2-gtkcheckmenuitem.html#GtkCheckMenuItem">GtkCheckMenuItem</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkRadioMenuItem.html">GtkRadioMenuItem</a> or <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImageMenuItem.html">GtkImageMenuItem</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html">GtkMenuItem</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-gtkcheckmenuitem.html#GtkCheckMenuItem">GtkCheckMenuItem</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkRadioMenuItem.html">GtkRadioMenuItem</a> or <a href="https://developer-old.gnome.org/gtk2/2.24/GtkImageMenuItem.html">GtkImageMenuItem</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.MenuItem.html">GtkMenuItem</a>, <a href="https://docs.gtk.org/gtk3/class.CheckMenuItem.html">GtkCheckMenuItem</a>, <a href="https://docs.gtk.org/gtk3/class.RadioMenuItem.html">GtkRadioMenuItem</a> or <a href="https://docs.gtk.org/gtk3/class.ImageMenuItem.html">GtkImageMenuItem</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;menuitem tag_attr=&quot;value&quot;...&gt;
@@ -102,7 +102,7 @@
 &lt;/menuitem&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html#GtkMenuItem.object-hierarchy">GtkMenuItem</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/gtk2-gtkcheckmenuitem.html#gtk-gtkcheckmenuitem.object-hierarchy">GtkCheckMenuItem</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkRadioMenuItem.html#GtkRadioMenuItem.object-hierarchy">GtkRadioMenuItem</a> or <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImageMenuItem.html#GtkImageMenuItem.object-hierarchy">GtkImageMenuItem</a> widget and ancestor class properties.</p>
+<p>See the GtkMenuItem, GtkCheckMenuItem, GtkRadioMenuItem or GtkImageMenuItem widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -133,13 +133,13 @@
 <tr>
 <td class="wiki">accel-key</td>
 <td class="wiki">Accelerator key</td>
-<td class="wiki">full list</a>)</td>
+<td class="wiki">A decimal or hexadecimal value (<a href="https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/gdkkeysyms.h">full list</a>)</td>
 <td class="wiki">0.7.21</td>
 </tr>
 <tr>
 <td class="wiki">accel-mods<sup>[1]</sup></td>
 <td class="wiki">Accelerator modifiers</td>
-<td class="wiki">full list</a>)</td>
+<td class="wiki">A decimal or hexadecimal value (<a href="https://gitlab.gnome.org/GNOME/gtk/-/blob/main/gdk/gdktypes.h">full list</a>)</td>
 <td class="wiki">0.7.21</td>
 </tr>
 <tr>
@@ -151,7 +151,7 @@
 <tr>
 <td class="wiki">stock-id</td>
 <td class="wiki">GTK stock icon ID</td>
-<td class="wiki">full list</a>)</td>
+<td class="wiki"><tt>gtk-about</tt>, <tt>gtk-add</tt>, ... (<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Stock-Items.html#GTK-STOCK-ABOUT:CAPS">full list</a> - Gtk2)</td>
 <td class="wiki">0.7.21</td>
 </tr>
 <tr>
@@ -301,11 +301,12 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal for the checkbox and radiobutton menuitem widgets is “<a href="http://developer-old.gnome.org/gtk2/2.24/gtk2-gtkcheckmenuitem.html#GtkCheckMenuItem-toggled">toggled</a>”, emitted when the state is changed, otherwise the default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html#GtkMenuItem-activate">activate</a>”, emitted when the item is activated.</p>
+<p>The default signal for the checkbox and radiobutton menuitem widgets is “toggled” (<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-gtkcheckmenuitem.html#GtkCheckMenuItem-toggled">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.CheckMenuItem.toggled.html">Gtk3</a>) emitted when the state is changed, otherwise the default signal is “activate” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkMenuItem.html#GtkMenuItem-activate">Gtk2</a> ,<a href="https://docs.gtk.org/gtk3/signal.MenuItem.activate.html">Gtk3</a>), emitted when the item is activated.</p>
 <p>All widgets emit the “activate” signal.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -401,7 +402,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -542,16 +543,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/menuitemseparator.html
+++ b/doc/reference/menuitemseparator.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,7 @@
 					<tr>
 						<td>
 <h1>menuitemseparator widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkSeparatorMenuItem.html">GtkSeparatorMenuItem</a></p>
+<p>A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkSeparatorMenuItem.html">GtkSeparatorMenuItem</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;menuitemseparator&gt;&lt;/menuitemseparator&gt;</code></pre>
@@ -137,16 +136,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/notebook.html
+++ b/doc/reference/notebook.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>notebook widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkNotebook.html">GtkNotebook</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkNotebook.html">GtkNotebook</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Notebook.html">GtkNotebook</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;notebook tag_attr=&quot;value&quot;...&gt;
@@ -98,7 +98,7 @@
 &lt;/notebook&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkNotebook.html#GtkNotebook.object-hierarchy">GtkNotebook</a> widget and ancestor class properties.</p>
+<p>See the GtkNotebook widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -240,7 +240,8 @@
 <p>There is no default signal for this widget.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -336,7 +337,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -429,7 +430,7 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li>This widget does not accept setting a default page before being shown (there’s a note about it <a href="http://developer-old.gnome.org/gtk2/2.24/GtkNotebook.html#gtk-notebook-set-current-page">here</a>) which will result in input data being discarded at start-up. This issue can be overcome by using the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkNotebook.html#GtkNotebook--page">page</a>” tag attribute which will be applied after the widget is shown.</li>
+<li>This widget does not accept setting a default page before being shown (there’s a note about it <a href="https://developer-old.gnome.org/gtk2/2.24/GtkNotebook.html#gtk-notebook-set-current-page">here (Gtk2)</a> and <a href="https://docs.gtk.org/gtk3/method.Notebook.set_current_page.html">here (Gtk3)</a>) which will result in input data being discarded at start-up. This issue can be overcome by using the “page” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkNotebook.html#GtkNotebook--page">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Notebook.page.html">Gtk3</a>) tag attribute which will be applied after the widget is shown.</li>
 </ol>
 <hr>
 <p>
@@ -474,16 +475,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/pixmap.html
+++ b/doc/reference/pixmap.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>pixmap widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImage.html">GtkImage</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkImage.html">GtkImage</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Image.html">GtkImage</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;pixmap tag_attr=&quot;value&quot;...&gt;
@@ -99,7 +99,7 @@
 &lt;/pixmap&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImage.html#GtkImage.object-hierarchy">GtkImage</a> widget and ancestor class properties.</p>
+<p>See the GtkImage widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -148,7 +148,7 @@
 <tr>
 <td class="wiki">stock-icon-size</td>
 <td class="wiki">The size of the GTK stock icon</td>
-<td class="wiki">GtkIconSize</a>)</td>
+<td class="wiki"><tt>0</tt> to <tt>6</tt> (see <a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Themeable-Stock-Images.html#GtkIconSize">GtkIconSize</a> - Gtk2)</td>
 <td class="wiki">0.8.1</td>
 </tr>
 </tbody>
@@ -202,7 +202,7 @@
 <tr>
 <td class="wiki">input file stock=“<em>gtk-image</em>”<sup>[2]</sup></td>
 <td class="wiki">GTK stock icon ID</td>
-<td class="wiki">full list</a>)</td>
+<td class="wiki"><tt>gtk-about</tt>, <tt>gtk-add</tt> ... (<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Stock-Items.html#GTK-STOCK-ABOUT:CAPS">full list</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -240,8 +240,8 @@
 <h2 id="signals">Signals</h2>
 <p>There is no default signal for this widget.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
-<p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -325,7 +325,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -464,16 +464,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/progressbar.html
+++ b/doc/reference/progressbar.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>progressbar widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkProgressBar.html">GtkProgressBar</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkProgressBar.html">GtkProgressBar</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.ProgressBar.html">GtkProgressBar</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;progressbar tag_attr=&quot;value&quot;...&gt;
@@ -97,7 +97,7 @@
 &lt;/progressbar&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkProgressBar.html#GtkProgressBar.object-hierarchy">GtkProgressBar</a> widget and ancestor class properties.</p>
+<p>See the GtkProgressBar widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -226,7 +226,8 @@
 <h2 id="signals">Signals</h2>
 <p>The default signal is “time-out”, emitted when the input data reaches 100.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -292,7 +293,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -428,16 +429,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/radiobutton.html
+++ b/doc/reference/radiobutton.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>radiobutton widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkRadioButton.html">GtkRadioButton</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkRadioButton.html">GtkRadioButton</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.RadioButton.html">GtkRadioButton</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;radiobutton tag_attr=&quot;value&quot;...&gt;
@@ -101,7 +101,7 @@
 &lt;/radiobutton&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkRadioButton.html#GtkRadioButton.object-hierarchy">GtkRadioButton</a> widget and ancestor class properties.</p>
+<p>See the GtkRadioButton widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -264,10 +264,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html#GtkToggleButton-toggled">toggled</a>”, emitted when the state is changed.</p>
+<p>The default signal is “toggled” for <a href="https://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html#GtkToggleButton-toggled">Gtk2</a> and “group-changed” for <a href="https://docs.gtk.org/gtk3/signal.RadioButton.group-changed.html">Gtk3</a>, emitted when the state is changed.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -375,7 +376,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -513,16 +514,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/separator.html
+++ b/doc/reference/separator.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,7 @@
 					<tr>
 						<td>
 <h1>separator widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkSeparatorMenuItem.html">GtkSeparatorMenuItem</a></p>
+<p>A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkSeparatorMenuItem.html">GtkSeparatorMenuItem</a></p>
 <hr>
 <h2 id="notes">Notes</h2>
 <p>This widget has been deprecated since 0.7.21 and <a href="menuitemseparator.html">menuitemseparator</a> should be used instead.</p>
@@ -131,16 +130,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/spinbutton.html
+++ b/doc/reference/spinbutton.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>spinbutton widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkSpinButton.html">GtkSpinButton</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkSpinButton.html">GtkSpinButton</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.SpinButton.html">GtkSpinButton</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;spinbutton tag_attr=&quot;value&quot;...&gt;
@@ -100,7 +100,7 @@
 &lt;/spinbutton&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkSpinButton.html#GtkSpinButton.object-hierarchy">GtkSpinButton</a> widget and ancestor class properties.</p>
+<p>See the GtkSpinButton widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -281,13 +281,14 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkSpinButton.html#GtkSpinButton-value-changed">value-changed</a>”, emitted when the range value changes.</p>
+<p>The default signal is “value-changed” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkSpinButton.html#GtkSpinButton-value-changed">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.SpinButton.value-changed.html">Gtk3</a>) emitted when the range value changes.</p>
 <p>The “changed” signal is emitted when typing into the entry.</p>
-<p>The “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-activate">activate</a>” signal is emitted when the user activates the entry with the Enter key.</p>
-<p>For GTK+ 2.16 and later, the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-icon-press">icon-press</a>” and “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-icon-release">icon-release</a>” signals are emitted when an activatable icon is pressed or released, but these signal names will be prefixed with either “primary-” or “secondary-” to indicate the source icon.</p>
+<p>The “activate” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-activate">Gtk2</a>) signal is emitted when the user activates the entry with the Enter key.</p>
+<p>For GTK+ 2.16 and later, the “<a href="https://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-icon-press">icon-press</a>” and “<a href="https://developer-old.gnome.org/gtk2/2.24/GtkEntry.html#GtkEntry-icon-release">icon-release</a>” signals are emitted when an activatable icon is pressed or released, but these signal names will be prefixed with either “primary-” or “secondary-” to indicate the source icon.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -389,7 +390,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -525,16 +526,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/statusbar.html
+++ b/doc/reference/statusbar.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>statusbar widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkStatusbar.html">GtkStatusbar</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkStatusbar.html">GtkStatusbar</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Statusbar.html">GtkStatusbar</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;statusbar tag_attr=&quot;value&quot;...&gt;
@@ -99,7 +99,7 @@
 &lt;/statusbar&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkStatusbar.html#GtkStatusbar.object-hierarchy">GtkStatusbar</a> widget and ancestor class properties.</p>
+<p>See the GtkStatusbar widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -154,7 +154,7 @@
 <tr>
 <td class="wiki">fs-filters-mime</td>
 <td class="wiki">fileselect function mime-type file filters</td>
-<td class="wiki">... (<a href="http://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
+<td class="wiki">... (<a href="https://en.wikipedia.org/wiki/Internet_media_type#List_of_common_media_types">common types</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -253,7 +253,8 @@
 <p>There is no default signal for this widget.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -355,7 +356,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -491,16 +492,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/table.html
+++ b/doc/reference/table.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,7 @@
 					<tr>
 						<td>
 <h1>table widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCList.html">GtkCList</a> packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkCList.html">GtkCList</a> packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
 <p>This widget has been deprecated since GTK+ 2.0 and <a href="tree.html">tree</a> is recommended as a replacement. <strong>It has been removed from GTK+ 3.0</strong></p>
 <hr>
 <h2>Definition</h2>
@@ -104,7 +103,7 @@
 &lt;/table&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkCList.html#GtkCList.object-hierarchy">GtkCList</a> widget and ancestor class properties.</p>
+<p>See the <a href="https://developer-old.gnome.org/gtk2/2.24/GtkCList.html#GtkCList.object-hierarchy">GtkCList</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -339,10 +338,10 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkCList.html#GtkCList-select-row">select-row</a>”, emitted when the user selects a row in the list.</p>
+<p>The default signal is “<a href="https://developer-old.gnome.org/gtk2/2.24/GtkCList.html#GtkCList-select-row">select-row</a>”, emitted when the user selects a row in the list.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -450,7 +449,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -544,9 +543,9 @@
 <h2 id="notes">Notes</h2>
 <ol type="1">
 <li>This widget has a default dimension of 200x100 which can be overridden with the height and/or width directives.</li>
+<li>This widget has been deprecated since GTK+ 2.0 and <a href="tree.html">tree</a> is recommended as a replacement.</li>
+<li>This widget has been removed from GTK+ 3.</li>
 </ol>
-<p>This widget has been deprecated since GTK+ 2.0 and <a href="tree.html">tree</a> is recommended as a replacement.</p>
-<p>This widget has been removed from GTK+ 3.</p>
 <hr>
 <p>
 <a href="button.html">button</a>, 
@@ -590,16 +589,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/terminal.html
+++ b/doc/reference/terminal.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,7 @@
 					<tr>
 						<td>
 <h1>terminal widget</h1>
-<p>A <a href="http://developer-old.gnome.org/vte/unstable/VteTerminal.html">VteTerminal</a> packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>A <a href="https://developer-old.gnome.org/vte/unstable/VteTerminal.html">VteTerminal</a> packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;terminal tag_attr=&quot;value&quot;...&gt;
@@ -100,7 +99,7 @@
 &lt;/terminal&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/vte/unstable/VteTerminal.html#VteTerminal.object-hierarchy">VteTerminal</a> widget and ancestor class properties.</p>
+<p>See the <a href="https://developer-old.gnome.org/vte/unstable/VteTerminal.html#VteTerminal.object-hierarchy">VteTerminal</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -335,10 +334,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/vte/unstable/VteTerminal.html#VteTerminal-child-exited">child-exited</a>”, emitted when the terminal detects that the child has exited.</p>
+<p>The default signal is “<a href="https://developer-old.gnome.org/vte/unstable/VteTerminal.html#VteTerminal-child-exited">child-exited</a>”, emitted when the terminal detects that the child has exited.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -434,7 +434,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki"></td>
 </tr>
@@ -527,10 +527,10 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li>There exists an equivalently named “<a href="http://developer-old.gnome.org/vte/unstable/VteTerminal.html#VteTerminal--background-tint-color">background-tint-color</a>” VTE property but it doesn’t accept strings so it’s converted by Gtkdialog.</li>
+<li>There exists an equivalently named “<a href="https://developer-old.gnome.org/vte/unstable/VteTerminal.html#VteTerminal--background-tint-color">background-tint-color</a>” VTE property but it doesn’t accept strings so it’s converted by Gtkdialog.</li>
 <li>The “background-tint-color” and “dim-foreground-color” tag attributes are not permitted when using VTE &gt;= 0.38 (which is the case for gtk3).</li>
 </ol>
-<p>This is a non-mandatory widget that requires <a href="http://ftp.gnome.org/pub/gnome/sources/vte/">libvte</a> support be built into Gtkdialog at compile time.</p>
+<p>This is a non-mandatory widget that requires <a href="https://ftp.gnome.org/pub/gnome/sources/vte/">libvte</a> support be built into Gtkdialog at compile time.</p>
 <p>This widget was introduced in version 0.8.1.</p>
 <hr>
 <p>
@@ -575,16 +575,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/text.html
+++ b/doc/reference/text.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>text widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Label.html">GtkLabel</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;text tag_attr=&quot;value&quot;...&gt;
@@ -97,7 +97,7 @@
 &lt;/text&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkLabel.html#GtkLabel.object-hierarchy">GtkLabel</a> widget and ancestor class properties.</p>
+<p>See the GtkLabel widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -143,7 +143,7 @@
 <td class="wiki"><tt>0</tt>, <tt>1</tt>, <tt>2</tt> (always, automatic, never)</td>
 <td class="wiki">0.8.5</td>
 </tr>
-+<tr>
+<tr>
 <td class="wiki">vscrollbar-policy</td>
 <td class="wiki">Policy for the vertical scrollbar</td>
 <td class="wiki"><tt>0</tt>, <tt>1</tt>, <tt>2</tt> (always, automatic, never)</td>
@@ -170,7 +170,7 @@
 <tr>
 <td class="wiki">shadow-type</td>
 <td class="wiki">Viewport shadow type</td>
-<td class="wiki"><tt>0</tt> to <tt>4</tt> (see <a href="http://developer-old.gnome.org/gtk2/2.24/gtk2-Standard-Enumerations.html#GtkShadowType">GtkShadowType</a>)</td>
+<td class="wiki"><tt>0</tt> to <tt>4</tt> (see GtkShadowType <a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Standard-Enumerations.html#GtkShadowType">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/enum.ShadowType.html">Gtk3</a>)</td>
 <td class="wiki">0.8.5</td>
 </tr>
 <tr>
@@ -257,7 +257,8 @@
 <p>There is no default signal for this widget.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -353,7 +354,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -445,7 +446,7 @@
 </table>
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
-<p>Line wrapping is enabled by default for this widget which can be overridden with the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkLabel.html#GtkLabel--wrap">wrap</a>” tag attribute.</p>
+<p>Line wrapping is enabled by default for this widget which can be overridden with the “wrap” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkLabel.html#GtkLabel--wrap">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Label.wrap.html">Gtk3</a>) tag attribute.</p>
 <hr>
 <p>
 <a href="button.html">button</a>, 
@@ -489,16 +490,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/timer.html
+++ b/doc/reference/timer.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>timer widget</h1>
-<p>A <a href="http://developer-old.gnome.org/glib/unstable/glib-The-Main-Event-Loop.html#g-timeout-add">timer</a> attached to a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/glib/unstable/glib-The-Main-Event-Loop.html#g-timeout-add">timer</a> attached to a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/glib/func.timeout_add.html">timer</a> attached to a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;timer tag_attr=&quot;value&quot;...&gt;
@@ -98,7 +98,7 @@
 &lt;/timer&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget.properties">GtkWidget</a> widget properties<sup>[1]</sup>.</p>
+<p>See the GtkWidget widget properties<sup>[1]</sup>.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -246,7 +246,8 @@
 <p>The default signal is “tick”, a custom signal emitted when the timer times-out.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -330,7 +331,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -423,7 +424,7 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li><p>The “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget--visible">visible</a>” tag attribute will be required to hide the timer widget as it is visible by default.</p></li>
+<li><p>The “visible” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget--visible">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Widget.visible.html">Gtk3</a>) tag attribute will be required to hide the timer widget as it is visible by default.</p></li>
 <li><p>The default precision is seconds using a default interval of 1 second.</p></li>
 <li><p>The “sensitive” property i.e. its active state constitutes the data for this widget.</p></li>
 </ol>
@@ -471,16 +472,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/togglebutton.html
+++ b/doc/reference/togglebutton.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>togglebutton widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html">GtkToggleButton</a> containing either a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a>, a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkImage.html">GtkImage</a> or both packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkHBox.html">GtkHBox</a> or <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVBox.html">GtkVBox</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html">GtkToggleButton</a> containing either a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkLabel.html">GtkLabel</a>, a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkImage.html">GtkImage</a> or both packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkHBox.html">GtkHBox</a> or <a href="https://developer-old.gnome.org/gtk2/2.24/GtkVBox.html">GtkVBox</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.ToggleButton.html">GtkToggleButton</a> containing either a <a href="https://docs.gtk.org/gtk3/class.Label.html">GtkLabel</a>, a <a href="https://docs.gtk.org/gtk3/class.Image.html">GtkImage</a> or both packed inside a <a href="https://docs.gtk.org/gtk3/class.HBox.html">GtkHBox</a> or <a href="https://docs.gtk.org/gtk3/class.VBox.html">GtkVBox</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;togglebutton tag_attr=&quot;value&quot;...&gt;
@@ -104,7 +104,7 @@
 &lt;/togglebutton&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html#GtkToggleButton.object-hierarchy">GtkToggleButton</a> widget and ancestor class properties.</p>
+<p>See the GtkToggleButton widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -165,7 +165,7 @@
 <tr>
 <td class="wiki">stock-icon-size</td>
 <td class="wiki">The size of the GTK stock icon</td>
-<td class="wiki">GtkIconSize</a>)</td>
+<td class="wiki"><tt>0</tt> to <tt>6</tt> (see <a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Themeable-Stock-Images.html#GtkIconSize">GtkIconSize</a> - Gtk2)</td>
 <td class="wiki">0.8.1</td>
 </tr>
 </tbody>
@@ -237,7 +237,7 @@
 <tr>
 <td class="wiki">input file stock=“<em>gtk-image</em>”<sup>[4]</sup></td>
 <td class="wiki">GTK stock icon ID</td>
-<td class="wiki">full list</a>)</td>
+<td class="wiki"><tt>gtk-about</tt>, <tt>gtk-add</tt> ... (<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Stock-Items.html#GTK-STOCK-ABOUT:CAPS">full list</a>)</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -309,10 +309,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html#GtkToggleButton-toggled">toggled</a>”, emitted when the state is changed.</p>
+<p>The default signal is “toggled” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkToggleButton.html#GtkToggleButton-toggled">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.ToggleButton.toggled.html">Gtk3</a>), emitted when the state is changed.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -408,7 +409,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -501,8 +502,8 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li><p>The existing “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkButton.html#GtkButton--image-position">image-position</a>” GTK+ property – normally only applicable to stock buttons – has been extended to apply to all Gtkdialog buttons.</p></li>
-<li><p>The existing “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkBox.html#GtkBox--homogeneous">homogeneous</a>” GTK+ property – applicable to the hbox and vbox – can be used here to effect the box inside the button when including an image and a label.</p></li>
+<li><p>The existing “image-position” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkButton.html#GtkButton--image-position">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Button.image-position.html">Gtk3</a>) GTK+ property – normally only applicable to stock buttons – has been extended to apply to all Gtkdialog buttons.</p></li>
+<li><p>The existing “homogeneous” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkBox.html#GtkBox--homogeneous">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Box.homogeneous.html">Gtk3</a>) GTK+ property – applicable to the hbox and vbox – can be used here to affect the box inside the button when including an image and a label.</p></li>
 <li><p>Theme icons default to 20 and do not scale or refresh (the “theme-icon-size” custom tag attribute can be used to request a size).</p></li>
 <li><p>Stock icons default to GTK_ICON_SIZE_BUTTON and do not scale or refresh (the “stock-icon-size” custom tag attribute can be used to request a size).</p></li>
 <li><p>This widget’s actions can be conditionally executed (based upon its active state) by prepending its contents with <tt>if true</tt> or <tt>if false</tt> although 0.8.3 introduced a dedicated condition attribute which may be more suitable.</p></li>
@@ -551,16 +552,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/tree.html
+++ b/doc/reference/tree.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>tree widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkTreeView.html">GtkTreeView</a> packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkTreeView.html">GtkTreeView</a> packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.TreeView.html">GtkTreeView</a> packed inside a <a href="https://docs.gtk.org/gtk3/class.ScrolledWindow.html">GtkScrolledWindow</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;tree tag_attr=&quot;value&quot;...&gt;
@@ -109,7 +109,7 @@
 &lt;/tree&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkTreeView.html#GtkTreeView.object-hierarchy">GtkTreeView</a> widget and ancestor class properties.</p>
+<p>See the GtkTreeView widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -242,7 +242,7 @@
 <tr>
 <td class="wiki">stock-id</td>
 <td class="wiki">Default GTK stock icon ID for all rows</td>
-<td class="wiki">full list</a>)</td>
+<td class="wiki"><tt>gtk-about</tt>, <tt>gtk-add</tt> ... (<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Stock-Items.html#GTK-STOCK-ABOUT:CAPS">full list</a> - Gtk2)</td>
 <td class="wiki"></td>
 </tr>
 </tbody>
@@ -416,12 +416,13 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkTreeView.html#GtkTreeView-row-activated">row-activated</a>”, emitted when the user double-clicks a row and also when a row is selected and one of the keys Space, Shift+Space, Return or Enter is pressed.</p>
-<p>The “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkTreeSelection.html#GtkTreeSelection-changed">changed</a>” signal is emitted when the selection has changed (please see link about this).</p>
-<p>The “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkTreeView.html#GtkTreeView-cursor-changed">cursor-changed</a>” signal is emitted when the position of the cursor (focused cell) has changed.</p>
+<p>The default signal is “row-activated” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkTreeView.html#GtkTreeView-row-activated">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.TreeView.row-activated.html">Gtk3</a>), emitted when the user double-clicks a row and also when a row is selected and one of the keys Space, Shift+Space, Return or Enter is pressed.</p>
+<p>The “changed” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkTreeSelection.html#GtkTreeSelection-changed">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.TreeSelection.changed.html">Gtk3</a>) signal is emitted when the selection has changed (please see link about this).</p>
+<p>The “cursor-changed” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkTreeView.html#GtkTreeView-cursor-changed">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.TreeView.cursor-changed.html">Gtk3</a>) signal is emitted when the position of the cursor (focused cell) has changed.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -529,7 +530,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -668,16 +669,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/vbox.html
+++ b/doc/reference/vbox.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>vbox widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVBox.html">GtkVBox</a> optionally packed inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkViewport.html">GtkViewport</a> inside a <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkVBox.html">GtkVBox</a> optionally packed inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkViewport.html">GtkViewport</a> inside a <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScrolledWindow.html">GtkScrolledWindow</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.VBox.html">GtkVBox</a> optionally packed inside a <a href="https://docs.gtk.org/gtk3/class.Viewport.html">GtkViewport</a> inside a <a href="https://docs.gtk.org/gtk3/class.ScrolledWindow.html">GtkScrolledWindow</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;vbox tag_attr=&quot;value&quot;...&gt;
@@ -97,7 +97,7 @@
 &lt;/vbox&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVBox.html#GtkVBox.object-hierarchy">GtkVBox</a> widget and ancestor class properties.</p>
+<p>See the GtkVBox widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -158,7 +158,7 @@
 <tr>
 <td class="wiki">shadow-type</td>
 <td class="wiki">Viewport shadow type</td>
-<td class="wiki">GtkShadowType</a>)</td>
+<td class="wiki"><tt>0</tt> to <tt>4</tt> (see GtkShadowType <a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Standard-Enumerations.html#GtkShadowType">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/enum.ShadowType.html">Gtk3</a>)</td>
 <td class="wiki">0.8.1</td>
 </tr>
 </tbody>
@@ -232,7 +232,8 @@
 <h2 id="signals">Signals</h2>
 <p>There is no default signal for this widget.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -310,7 +311,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -406,7 +407,7 @@
 <li><p>By default the frame widget and every widget automatically placed inside a scrolled window (edit, tree, list, table and optionally the h/vbox) are packed with expand and fill set to true, otherwise widgets are packed with expand and fill set to false. This rather quirky system constitutes the original Gtkdialog widget packing method and therefore must continue to be supported, but since 0.7.21 it’s now possible to override this behaviour globally with the –space-expand=state and –space-fill=state command line options, at the h/vbox container level or at the individual widget level or a combination thereof.</p></li>
 <li><p>The scrolled window has a default dimension of 200x100 which can be overridden with the height and/or width directives.</p></li>
 </ol>
-<p>This widget has a default spacing of 5 which can be overridden with the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkBox.html#GtkBox--spacing">spacing</a>” tag attribute.</p>
+<p>This widget has a default spacing of 5 which can be overridden with the “spacing” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkBox.html#GtkBox--spacing">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Box.spacing.html">Gtk3</a>) tag attribute.</p>
 <hr>
 <p>
 <a href="button.html">button</a>, 
@@ -450,16 +451,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/vscale.html
+++ b/doc/reference/vscale.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>vscale widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVScale.html">GtkVScale</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkVScale.html">GtkVScale</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.VScale.html">GtkVScale</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;vscale tag_attr=&quot;value&quot;...&gt;
@@ -101,7 +101,7 @@
 &lt;/vscale&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVScale.html#GtkVScale.object-hierarchy">GtkVScale</a> widget and ancestor class properties.</p>
+<p>See the GtkVScale widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -275,8 +275,8 @@
 </tr>
 <tr>
 <td class="wiki">item</td>
-<td class="wiki">Input data for marks and markup<sup>[1]</sup></td>
-<td class="wiki">markup</a></em> (optional)</td>
+<td class="wiki">Input data for marks and markup<sup><a href="#note1">[1]</a></sup></td>
+<td class="wiki">value: <em>position</em><sup>(<a href="https://developer-old.gnome.org/gtk2/2.24/gtk2-Standard-Enumerations.html#GtkPositionType">gtk2</a>)</sup><sup>(<a href="https://docs.gtk.org/gtk3/enum.PositionType.html">gtk3</a>)</sup> <tt>|</tt> <em>markup</em><sup>(<a href="https://developer-old.gnome.org/pango/stable/PangoMarkupFormat.html">gtk2</a>)</sup><sup>(<a href="https://docs.gtk.org/Pango/pango_markup.html">gtk3</a>)</sup> (optional)</td>
 <td class="wiki"></td>
 </tr>
 <tr>
@@ -288,10 +288,11 @@
 </tbody>
 </table>
 <h2 id="signals">Signals</h2>
-<p>The default signal is “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkRange.html#GtkRange-value-changed">value-changed</a>”, emitted when the range value changes.</p>
+<p>The default signal is “value-changed” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkRange.html#GtkRange-value-changed">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/signal.Range.value-changed.html">Gtk3</a>), emitted when the range value changes.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -387,7 +388,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -480,7 +481,7 @@
 <p>true means “true”, “yes” or a non-zero value, false means “false”, “no” or zero, therefore the shell command is expected to echo one of these values to stdout.</p>
 <h2 id="notes">Notes</h2>
 <ol type="1">
-<li>Scale marks and markup require at least <a href="http://developer-old.gnome.org/gtk2/2.24/GtkScale.html#gtk-scale-add-mark">GTK+ 2.16</a>.</li>
+<li>Scale marks and markup require at least <a href="https://developer-old.gnome.org/gtk2/2.24/GtkScale.html#gtk-scale-add-mark">GTK+ 2.16</a>.</li>
 </ol>
 <p>This widget was introduced in version 0.7.21.</p>
 <hr>
@@ -526,16 +527,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/vseparator.html
+++ b/doc/reference/vseparator.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,14 +83,14 @@
 					<tr>
 						<td>
 <h1>vseparator widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVSeparator.html">GtkVSeparator</a></p>
+<p>A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkVSeparator.html">GtkVSeparator</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;vseparator tag_attr=&quot;value&quot;...&gt;
 &lt;/vseparator&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkVSeparator.html#GtkVSeparator.object-hierarchy">GtkVSeparator</a> widget and ancestor class properties.</p>
+<p>See the <a href="https://developer-old.gnome.org/gtk2/2.24/GtkVSeparator.html#GtkVSeparator.object-hierarchy">GtkVSeparator</a> widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -162,16 +161,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>

--- a/doc/reference/window.html
+++ b/doc/reference/window.html
@@ -1,5 +1,4 @@
-<!DOCTYPE html PUBLIC "-//W3C//DTD HTML 4.01 Transitional//EN"
-	"http://www.w3.org/TR/html4/loose.dtd">
+<!DOCTYPE html>
 
 <html>
 <head>
@@ -84,7 +83,8 @@
 					<tr>
 						<td>
 <h1>window widget</h1>
-<p>A <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWindow.html">GtkWindow</a></p>
+<p>Gtk2: A <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWindow.html">GtkWindow</a></p>
+<p>Gtk3: A <a href="https://docs.gtk.org/gtk3/class.Window.html">GtkWindow</a></p>
 <hr>
 <h2>Definition</h2>
 <pre><code>&lt;window tag_attr=&quot;value&quot;...&gt;
@@ -99,7 +99,7 @@
 &lt;/window&gt;</code></pre>
 <p>“…” denotes acceptance of multiples of the same thing.</p>
 <h2 id="tag-attributes">Tag Attributes</h2>
-<p>See the <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWindow.html#GtkWindow.object-hierarchy">GtkWindow</a> widget and ancestor class properties.</p>
+<p>See the GtkWindow widget and ancestor class properties.</p>
 <p>The following custom tag attributes are available:</p>
 <table class="wiki" border="1" cellpadding="5">
 <tr>
@@ -241,7 +241,8 @@
 <p>There is no default signal for this widget.</p>
 <p>The “file-changed” signal is emitted if file-monitor is true and the input file being monitored has changed.</p>
 <p>The following signals are connected-up for all widgets:</p>
-<p><a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="http://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk2: </strong><a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-press-event">button-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-button-release-event">button-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-configure-event">configure-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-enter-notify-event">enter-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-leave-notify-event">leave-notify-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-in-event">focus-in-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-focus-out-event">focus-out-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-hide">hide</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-show">show</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-realize">realize</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-press-event">key-press-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-key-release-event">key-release-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-map-event">map-event</a>, <a href="https://developer-old.gnome.org/gtk2/2.24/GtkWidget.html#GtkWidget-unmap-event">unmap-event</a></p>
+<p><strong>Gtk3: </strong><a href="https://docs.gtk.org/gtk3/signal.Widget.button-press-event.html">button-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.button-release-event.html">button-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.configure-event.html">configure-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.enter-notify-event.html">enter-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.leave-notify-event.html">leave-notify-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-in-event.html">focus-in-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.focus-out-event.html">focus-out-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.hide.html">hide</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.show.html">show</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.realize.html">realize</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-press-event.html">key-press-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.key-release-event.html">key-release-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.map-event.html">map-event</a>, <a href="https://docs.gtk.org/gtk3/signal.Widget.unmap-event.html">unmap-event</a></p>
 <h2 id="functions">Functions</h2>
 <p>The following functions can be performed upon this widget by any widget capable of emitting signals:</p>
 <table class="wiki" border="1" cellpadding="5">
@@ -337,7 +338,7 @@
 </tr>
 <tr>
 <td class="wiki">presentwindow</td>
-<td class="wiki">Present</a> dialog</td>
+<td class="wiki">Present dialog</td>
 <td class="wiki">Variable name</td>
 <td class="wiki">0.8.1</td>
 </tr>
@@ -432,13 +433,13 @@
 <ol type="1">
 <li><p>The “title” property constitutes the data for this widget.</p></li>
 <li><p>This widget is a container which accepts only one child widget so you may require that to be an hbox or vbox.</p></li>
-<li><p>This widget has a default border width of 5 which can be overridden with the “<a href="http://developer-old.gnome.org/gtk2/2.24/GtkContainer.html#GtkContainer--border-width">border-width</a>” tag attribute.</p></li>
+<li><p>This widget has a default border width of 5 which can be overridden with the “border-width” (<a href="https://developer-old.gnome.org/gtk2/2.24/GtkContainer.html#GtkContainer--border-width">Gtk2</a>, <a href="https://docs.gtk.org/gtk3/property.Container.border-width.html">Gtk3</a>) tag attribute.</p></li>
 </ol>
 <h2 id="wayland">Wayland</h2>
 <p>Support for Wayland compositors is only available if you build against <tt>gtk-3</tt> using the <tt>meson</tt> build system instead of gnu <tt>autotools</tt>, however <tt>gtkdialog</tt> will still work if using <tt>autotools</tt> and <tt>gtk-3</tt>, just without Wayland modifications.</p>
 <h3 id="notes-for-wayland">Notes for Wayland</h3>
 <ol type="1">
-<li><p><tt>-G, --geometry</tt> CLI option does not work on Wayland. Used <tt>edge</tt></p></li>
+<li><p><tt>-G, --geometry</tt> CLI option does not work on Wayland. Use <tt>edge</tt></p></li>
 <li><p>tag attribute <tt>decorated</tt> is ignored on Wayland. Use <tt>layer</tt></p></li>
 </ol>
 <hr>
@@ -484,16 +485,14 @@
 </p>
 
 							<p>&nbsp;</p>
-							<p align="center"><strong>For GTK+ 3 reference see <a href="https://docs.gtk.org/gtk3/">the Gtk-3.0 docs</a> page</strong></p>
 						</td>
 					</tr>
 					<tr>
 						<td>
 							<table width="100%" cellpadding="0" cellspacing="0">
 								<tr>
-									<td class="footer" width="33%" align="center">2013-04-01 <a href="mailto:thunorsif@hotmail.com">Thunor</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://code.google.com/p/gtkdialog/">Project Page</a></td>
-									<td class="footer" width="33%" align="center"><a href="http://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://github.com/puppylinux-woof-CE/gtkdialog">Project Page</a></td>
+									<td class="footer" width="50%" align="center"><a href="https://www.murga-linux.com/puppy/viewtopic.php?t=69188">Development Thread</a></td>
 								</tr>
 							</table>
 						</td>


### PR DESCRIPTION
- general cleanup fixing typos and broken links
- add Gtk3 links along side Gtk2 links where necessary
- made sure all links use https
re #143 