### PR TITLE
widget_window.c: bugfix for regression in 262be11

### DIFF
--- a/src/widget_window.c
+++ b/src/widget_window.c
@@ -177,10 +177,11 @@ layer_set:
 #endif
 
 	/* app id and theme window/taskbar icon */
-	value = get_tag_attribute(attr, "icon-name");
-	if (value) {
-		gtk_window_set_icon_name(GTK_WINDOW(widget), value);
-		g_set_prgname(value);
+	if (attr) {
+		if (value = get_tag_attribute(attr, "icon-name")) {
+			gtk_window_set_icon_name(GTK_WINDOW(widget), value);
+			g_set_prgname(value);
+		}
 	}
 
 	/* Set a default window title */


### PR DESCRIPTION
- no need for an attr in the top-level widget
- this works again now
 `gtkdialog -s <<< '<button ok></button>'`