### PR TITLE
meson: add docs to install; default is false

### DIFF
--- a/doc/meson.build
+++ b/doc/meson.build
@@ -1,0 +1,3 @@
+install_subdir(
+	'reference', install_dir : join_paths(get_option('datadir'), 'doc')
+	)

--- a/meson.build
+++ b/meson.build
@@ -17,5 +17,12 @@ else
 	vte = dependency('vte', required: false)
 endif
 
+if get_option('docs')
+	subdir('doc')
+	install_subdir(
+	'examples', install_dir : join_paths(get_option('datadir'), 'doc')
+	)
+endif
+
 subdir('src')
 subdir('data')

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,1 +1,2 @@
 option('gtkver', type: 'integer', value: 3, description: 'GTK+ version')
+option('docs', type: 'boolean', value: false, description: 'add html documentation and examples')


### PR DESCRIPTION
- adds documentation and examples if `-Ddocs=true`
- disabled if not explicitly set as 'true' on meson command line