### PR TITLE
Use system-provided gtk-layer-shell if possible

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -11,7 +11,7 @@ jobs:
     - name: Install dependencies
       run: |
         sudo apt-get update -qq
-        sudo apt-get install -y --no-install-recommends libgtk2.0-dev libgtk-3-dev libvte-dev libvte-2.91-dev
+        sudo apt-get install -y --no-install-recommends libgtk2.0-dev libgtk-3-dev libvte-dev libvte-2.91-dev libgtk-layer-shell-dev
         python3 -m pip install meson ninja
     - name: Copy source
       run: |

--- a/meson.build
+++ b/meson.build
@@ -7,11 +7,15 @@ gtkver = get_option('gtkver')
 if gtkver == 3
 	gtk = dependency('gtk+-3.0')
 	vte = dependency('vte-2.91', required: false)
-	gtk_layer_shell = subproject(
-		'gtk-layer-shell',
-		default_options: ['default_library=static', 'introspection=false'],
-		required: false,
-	)
+	gtk_layer_shell = dependency('gtk-layer-shell-0', required: false)
+	if not gtk_layer_shell.found()
+		proj = subproject(
+			'gtk-layer-shell',
+			default_options: ['default_library=static', 'introspection=false'],
+			required: false,
+		)
+		gtk_layer_shell = proj.get_variable('gtk_layer_shell')
+	endif
 else
 	gtk = dependency('gtk+-2.0')
 	vte = dependency('vte', required: false)

--- a/src/meson.build
+++ b/src/meson.build
@@ -73,8 +73,8 @@ if vte.found()
 else
 	cfg.set('HAVE_VTE', 0)
 endif
-if gtkver == 3 and gtk_layer_shell.found()
-	dep += [gtk_layer_shell.get_variable('gtk_layer_shell')]
+if gtkver == 3
+	dep += [gtk_layer_shell]
 	cfg.set('HAVE_GTK_LAYER_SHELL', 1)
 else
 	cfg.set('HAVE_GTK_LAYER_SHELL', 0)


### PR DESCRIPTION
gtk-layer-shell is sensitive to the GTK+ version, and the system-provided one is more likely to work.