### PR TITLE
Fix build failure if wayland-scanner is missing

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -14,7 +14,9 @@ if gtkver == 3
 			default_options: ['default_library=static', 'introspection=false'],
 			required: false,
 		)
-		gtk_layer_shell = proj.get_variable('gtk_layer_shell')
+		if proj.found()
+			gtk_layer_shell = proj.get_variable('gtk_layer_shell')
+		endif
 	endif
 else
 	gtk = dependency('gtk+-2.0')

--- a/src/meson.build
+++ b/src/meson.build
@@ -73,7 +73,7 @@ if vte.found()
 else
 	cfg.set('HAVE_VTE', 0)
 endif
-if gtkver == 3
+if gtkver == 3 and gtk_layer_shell.found()
 	dep += [gtk_layer_shell]
 	cfg.set('HAVE_GTK_LAYER_SHELL', 1)
 else


### PR DESCRIPTION
8ab7b64 makes gtk-layer-shell a mandatory dependency.

It looks like some older Puppies have some Wayland development packages, because they're dependencies of GTK+ 3's development packages, but not all of them. The dependency chain is broken.

In particular, libwayland-bin is missing and assumed to be installed, so /usr/bin/wayland-scanner is missing and the gtk-layer-shell must be disabled to prevent build failure.

People will complain they can't build the latest gtkdialog, so let's keep the subproject fallback, but disable gtk-layer-shell support completely if the subproject has missing dependencies.