### PR TITLE
fix exclusive zone, bump gtk-layer-shell version

### DIFF
--- a/src/widget_window.c
+++ b/src/widget_window.c
@@ -162,7 +162,7 @@ GtkWidget *widget_window_create(
 		gtk_layer_set_layer(GTK_WINDOW(widget), layer);
 	}
 	if (edge != GTK_LAYER_SHELL_EDGE_ENTRY_NUMBER) {
-		gtk_layer_auto_exclusive_zone_enable (GTK_WINDOW(widget));
+		gtk_layer_set_exclusive_zone (GTK_WINDOW(widget), 0);
 		gtk_layer_set_margin(GTK_WINDOW(widget), GTK_LAYER_SHELL_EDGE_LEFT, 20);
 		gtk_layer_set_margin(GTK_WINDOW(widget), GTK_LAYER_SHELL_EDGE_RIGHT, 20);
 		gtk_layer_set_margin(GTK_WINDOW(widget), GTK_LAYER_SHELL_EDGE_TOP, 10);

--- a/subprojects/gtk-layer-shell.wrap
+++ b/subprojects/gtk-layer-shell.wrap
@@ -1,3 +1,3 @@
 [wrap-git]
 url = https://github.com/wmww/gtk-layer-shell
-revision = ca37ef1baa623302dda5fcea200d04e0d9a10578
+revision = 0.8.1


### PR DESCRIPTION
Before programs such as `yaf-spalsh, gtkdialog-splash` were pushing widows out of the way in wayland. That shouldn't happen.

Also bumped `gtk-layer-shell` version to 'latest stable'