### PR TITLE
Add build option to run commands via bash -c

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,13 +22,13 @@ jobs:
       run: |
         meson --buildtype=release -Dgtkver=2 build
         ninja -C build
-        DESTDIR=/tmp/meson-gtk3 ninja -C build install
+        DESTDIR=/tmp/meson-gtk2 ninja -C build install
         cd ../gtk3-meson
         meson --buildtype=release build
         ninja -C build
         meson configure build -Dbash=true
         ninja -C build
-        DESTDIR=/tmp/meson-gtk2 ninja -C build install
+        DESTDIR=/tmp/meson-gtk3 ninja -C build install
     - name: Autotools build
       run: |
         cd ../gtk2-autotools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -26,6 +26,8 @@ jobs:
         cd ../gtk3-meson
         meson --buildtype=release build
         ninja -C build
+        meson configure build -Dbash=true
+        ninja -C build
         DESTDIR=/tmp/meson-gtk2 ninja -C build install
     - name: Autotools build
       run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout code
-      uses: actions/checkout@v2
+      uses: actions/checkout@v3
     - name: Install dependencies
       run: |
         sudo apt-get update -qq

--- a/meson_options.txt
+++ b/meson_options.txt
@@ -1,2 +1,3 @@
 option('gtkver', type: 'integer', value: 3, description: 'GTK+ version')
 option('docs', type: 'boolean', value: false, description: 'add html documentation and examples')
+option('bash', type: 'boolean', value: false, description: 'run commands using bash -c')

--- a/src/actions.c
+++ b/src/actions.c
@@ -36,6 +36,7 @@
 #include "attributes.h"
 #include "variables.h"
 #include "tag_attributes.h"
+#include "config.h"
 
 extern gchar *option_include_file;
 
@@ -642,18 +643,37 @@ void action_presentwindow(GtkWidget *widget, char *string)
 /***********************************************************************
  * Action command                                                      *
  ***********************************************************************/
-/* This fuction will export variables and run a shell command */
 
+static void _action_shellcommand(const char *command)
+{
+#if HAVE_BASH
+	char *argv[] = {"bash", "-c", command, NULL};
+
+	g_spawn_sync(NULL,
+	             argv,
+	             NULL,
+	             G_SPAWN_LEAVE_DESCRIPTORS_OPEN | G_SPAWN_SEARCH_PATH,
+	             NULL,
+	             NULL,
+	             NULL,
+	             NULL,
+	             NULL,
+	             NULL);
+#else
+	system(command);
+#endif
+}
+
+/* This fuction will export variables and run a shell command */
 void action_shellcommand(GtkWidget *widget, char *string)
 {
 	char *command;
-	int result;
 
 	variables_export_all();
 
 	if (option_include_file == NULL) {
 
-		result = system(string);
+		_action_shellcommand(string);
 
 	} else {
 
@@ -661,7 +681,7 @@ void action_shellcommand(GtkWidget *widget, char *string)
 		command = g_strdup_printf("source %s; %s", */
 		command = g_strdup_printf(". %s; %s",
 				option_include_file, string);
-		result = system(command);
+		_action_shellcommand(command);
 		g_free(command);
 
 	}

--- a/src/meson.build
+++ b/src/meson.build
@@ -79,6 +79,11 @@ if gtkver == 3 and gtk_layer_shell.found()
 else
 	cfg.set('HAVE_GTK_LAYER_SHELL', 0)
 endif
+if get_option('bash')
+	cfg.set('HAVE_BASH', 1)
+else
+	cfg.set('HAVE_BASH', 0)
+endif
 
 configure_file(
 	output : 'config.h',


### PR DESCRIPTION
/bin/sh is bash in Puppy, but not in all distros. I want to switch to dash as /bin/sh in dpup, to avoid the overhead of bash.

However, some gtkdialog-based tools assume that the shell is bash (for example, they use `export -f` and call the exported functions via `<action>`) and things "just work" because system() runs `sh -c`.

This PR adds a built option, `-Dbash=true`, which makes gtkdialog run commands via `bash -c` instead of `sh -c`.